### PR TITLE
Update locales.php from wp.org

### DIFF
--- a/lib/glotpress/locales.php
+++ b/lib/glotpress/locales.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Locales used on WordPress.org.
+ *
+ * - Copy of https://github.com/GlotPress/GlotPress-WP/blob/4e75ab6/locales/locales.php
+ * - With support for custom locale variants.
+ * - Without https://github.com/GlotPress/GlotPress-WP/pull/1012 and https://github.com/GlotPress/GlotPress-WP/pull/1017.
+ * - Without other dependencies because the file gets also loaded in api.wordpress.org context.
+ */
 if ( ! class_exists( 'GP_Locale' ) ) :
 
 class GP_Locale {
@@ -16,6 +24,25 @@ class GP_Locale {
 	public $google_code = null;
 	public $preferred_sans_serif_font_family = null;
 	public $facebook_locale = null;
+
+	/**
+	 * The variant root for this locale.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	public $variant_root = null;
+
+	/**
+	 * The variants of this locale.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var array
+	 */
+	public $variants = null;
+
 	// TODO: days, months, decimals, quotes
 
 	private $_index_for_number;
@@ -87,6 +114,16 @@ class GP_Locale {
 		return $f( $number );
 	}
 
+	/**
+	 * When converting the object to a string, the combined name is returned.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string Combined name of locale.
+	 */
+	public function __toString() {
+		return $this->combined_name();
+	}
 }
 
 endif;
@@ -128,7 +165,6 @@ class GP_Locales {
 		$ak->native_name = 'Akan';
 		$ak->lang_code_iso_639_1 = 'ak';
 		$ak->lang_code_iso_639_2 = 'aka';
-		$ak->wp_locale = 'ak';
 		$ak->slug = 'ak';
 		$ak->facebook_locale = 'ak_GH';
 
@@ -147,7 +183,9 @@ class GP_Locales {
 		$an->native_name = 'Aragonés';
 		$an->lang_code_iso_639_1 = 'an';
 		$an->lang_code_iso_639_2 = 'arg';
+		$an->lang_code_iso_639_3 = 'arg';
 		$an->country_code = 'es';
+		$an->wp_locale = 'arg';
 		$an->slug = 'an';
 
 		$ar = new GP_Locale();
@@ -158,7 +196,7 @@ class GP_Locales {
 		$ar->wp_locale = 'ar';
 		$ar->slug = 'ar';
 		$ar->nplurals = 6;
-		$ar->plural_expression = 'n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5';
+		$ar->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))))';
 		$ar->text_direction = 'rtl';
 		$ar->preferred_sans_serif_font_family = 'Tahoma';
 		$ar->google_code = 'ar';
@@ -173,7 +211,7 @@ class GP_Locales {
 		$arq->wp_locale = 'arq';
 		$arq->slug = 'arq';
 		$arq->nplurals = 6;
-		$arq->plural_expression = 'n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5';
+		$arq->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))))';
 		$arq->text_direction = 'rtl';
 
 		$ary = new GP_Locale();
@@ -185,7 +223,7 @@ class GP_Locales {
 		$ary->wp_locale = 'ary';
 		$ary->slug = 'ary';
 		$ary->nplurals = 6;
-		$ary->plural_expression = 'n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5';
+		$ary->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))))';
 		$ary->text_direction = 'rtl';
 
 		$as = new GP_Locale();
@@ -220,6 +258,7 @@ class GP_Locales {
 		$ay->native_name = 'aymar aru';
 		$ay->lang_code_iso_639_1 = 'ay';
 		$ay->lang_code_iso_639_2 = 'aym';
+		$ay->country_code = 'bo';
 		$ay->slug = 'ay';
 		$ay->nplurals = 1;
 		$ay->plural_expression = '0';
@@ -291,7 +330,7 @@ class GP_Locales {
 		$be->wp_locale = 'bel';
 		$be->slug = 'bel';
 		$be->nplurals = 3;
-		$be->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$be->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$be->google_code = 'be';
 		$be->facebook_locale = 'be_BY';
 
@@ -313,6 +352,14 @@ class GP_Locales {
 		$bh->lang_code_iso_639_2 = 'bih';
 		$bh->slug = 'bh';
 
+		$bho = new GP_Locale();
+		$bho->english_name = 'Bhojpuri';
+		$bho->native_name = 'भोजपुरी';
+		$bho->lang_code_iso_639_3 = 'bho';
+		$bho->country_code = 'in';
+		$bho->wp_locale = 'bho';
+		$bho->slug = 'bho';
+
 		$bi = new GP_Locale();
 		$bi->english_name = 'Bislama';
 		$bi->native_name = 'Bislama';
@@ -329,14 +376,25 @@ class GP_Locales {
 		$bm->slug = 'bm';
 
 		$bn_bd = new GP_Locale();
-		$bn_bd->english_name = 'Bengali';
+		$bn_bd->english_name = 'Bengali (Bangladesh)';
 		$bn_bd->native_name = 'বাংলা';
 		$bn_bd->lang_code_iso_639_1 = 'bn';
-		$bn_bd->country_code = 'bn';
+		$bn_bd->country_code = 'bd';
 		$bn_bd->wp_locale = 'bn_BD';
 		$bn_bd->slug = 'bn';
 		$bn_bd->google_code = 'bn';
-		$bn_bd->facebook_locale = 'bn_IN';
+
+		$bn_in = new GP_Locale();
+		$bn_in->english_name = 'Bengali (India)';
+		$bn_in->native_name = 'বাংলা (ভারত)';
+		$bn_in->lang_code_iso_639_1 = 'bn';
+		$bn_in->country_code = 'in';
+		$bn_in->wp_locale = 'bn_IN';
+		$bn_in->slug = 'bn-in';
+		$bn_in->google_code = 'bn';
+		$bn_in->facebook_locale = 'bn_IN';
+		$bn_in->nplurals = 2;
+		$bn_in->plural_expression = 'n > 1';
 
 		$bo = new GP_Locale();
 		$bo->english_name = 'Tibetan';
@@ -358,8 +416,16 @@ class GP_Locales {
 		$br->wp_locale = 'bre';
 		$br->slug = 'br';
 		$br->nplurals = 2;
-		$br->plural_expression = '(n > 1)';
+		$br->plural_expression = 'n > 1';
 		$br->facebook_locale = 'br_FR';
+
+		$brx = new GP_Locale();
+		$brx->english_name = 'Bodo';
+		$brx->native_name = 'बोडो‎';
+		$brx->lang_code_iso_639_3 = 'brx';
+		$brx->country_code = 'in';
+		$brx->wp_locale = 'brx';
+		$brx->slug = 'brx';
 
 		$bs = new GP_Locale();
 		$bs->english_name = 'Bosnian';
@@ -370,7 +436,7 @@ class GP_Locales {
 		$bs->wp_locale = 'bs_BA';
 		$bs->slug = 'bs';
 		$bs->nplurals = 3;
-		$bs->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$bs->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$bs->google_code = 'bs';
 		$bs->facebook_locale = 'bs_BA';
 
@@ -428,6 +494,18 @@ class GP_Locales {
 		$co->wp_locale = 'co';
 		$co->slug = 'co';
 
+		$cor = new GP_Locale();
+		$cor->english_name = 'Cornish';
+		$cor->native_name = 'Kernewek';
+		$cor->lang_code_iso_639_1 = 'kw';
+		$cor->lang_code_iso_639_2 = 'cor';
+		$cor->lang_code_iso_639_2 = 'cor';
+		$cor->country_code = 'gb';
+		$cor->wp_locale = 'cor';
+		$cor->slug = 'cor';
+		$cor->nplurals = 6;
+		$cor->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : (((n % 100 == 2 || n % 100 == 22 || n % 100 == 42 || n % 100 == 62 || n % 100 == 82) || n % 1000 == 0 && (n % 100000 >= 1000 && n % 100000 <= 20000 || n % 100000 == 40000 || n % 100000 == 60000 || n % 100000 == 80000) || n != 0 && n % 1000000 == 100000) ? 2 : ((n % 100 == 3 || n % 100 == 23 || n % 100 == 43 || n % 100 == 63 || n % 100 == 83) ? 3 : ((n != 1 && (n % 100 == 1 || n % 100 == 21 || n % 100 == 41 || n % 100 == 61 || n % 100 == 81)) ? 4 : 5))))';
+
 		$cr = new GP_Locale();
 		$cr->english_name = 'Cree';
 		$cr->native_name = 'ᓀᐦᐃᔭᐍᐏᐣ';
@@ -445,7 +523,7 @@ class GP_Locales {
 		$cs->wp_locale = 'cs_CZ';
 		$cs->slug = 'cs';
 		$cs->nplurals = 3;
-		$cs->plural_expression = '(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2';
+		$cs->plural_expression = '(n == 1) ? 0 : ((n >= 2 && n <= 4) ? 1 : 2)';
 		$cs->google_code = 'cs';
 		$cs->facebook_locale = 'cs_CZ';
 
@@ -506,6 +584,22 @@ class GP_Locales {
 		$de->google_code = 'de';
 		$de->facebook_locale = 'de_DE';
 
+		$de_formal = clone $de;
+		$de_formal->english_name = 'German (Formal)';
+		$de_formal->native_name = 'Deutsch (Sie)';
+		$de_formal->slug = 'de/formal';
+		$de_formal->wp_locale = 'de_DE_formal';
+		$de_formal->root_slug = $de->slug;
+
+		$de_at = new GP_Locale();
+		$de_at->english_name = 'German (Austria)';
+		$de_at->native_name = 'Deutsch (Österreich)';
+		$de_at->lang_code_iso_639_1 = 'de';
+		$de_at->country_code = 'de';
+		$de_at->wp_locale = 'de_AT';
+		$de_at->slug = 'de-at';
+		$de_at->google_code = 'de';
+
 		$de_ch = new GP_Locale();
 		$de_ch->english_name = 'German (Switzerland)';
 		$de_ch->native_name = 'Deutsch (Schweiz)';
@@ -514,6 +608,24 @@ class GP_Locales {
 		$de_ch->wp_locale = 'de_CH';
 		$de_ch->slug = 'de-ch';
 		$de_ch->google_code = 'de';
+
+		$de_ch_informal = clone $de_ch;
+		$de_ch_informal->english_name = 'German (Switzerland, Informal)';
+		$de_ch_informal->native_name = 'Deutsch (Schweiz, Du)';
+		$de_ch_informal->slug = 'de-ch/informal';
+		$de_ch_informal->wp_locale = 'de_CH_informal';
+		$de_ch_informal->root_slug = $de_ch->slug;
+
+		$dsb = new GP_Locale();
+		$dsb->english_name = 'Lower Sorbian';
+		$dsb->native_name = 'Dolnoserbšćina';
+		$dsb->lang_code_iso_639_2 = 'dsb';
+		$dsb->lang_code_iso_639_3 = 'dsb';
+		$dsb->country_code = 'de';
+		$dsb->wp_locale = 'dsb';
+		$dsb->slug = 'dsb';
+		$dsb->nplurals = 4;
+		$dsb->plural_expression = '(n % 100 == 1) ? 0 : ((n % 100 == 2) ? 1 : ((n % 100 == 3 || n % 100 == 4) ? 2 : 3))';
 
 		$dv = new GP_Locale();
 		$dv->english_name = 'Dhivehi';
@@ -546,12 +658,6 @@ class GP_Locales {
 		$ewe->wp_locale = 'ewe';
 		$ewe->slug = 'ee';
 
-		$el_po = new GP_Locale();
-		$el_po->english_name = 'Greek (Polytonic)';
-		$el_po->native_name = 'Greek (Polytonic)'; // TODO
-		$el_po->country_code = 'gr';
-		$el_po->slug = 'el-po';
-
 		$el = new GP_Locale();
 		$el->english_name = 'Greek';
 		$el->native_name = 'Ελληνικά';
@@ -562,6 +668,12 @@ class GP_Locales {
 		$el->slug = 'el';
 		$el->google_code = 'el';
 		$el->facebook_locale = 'el_GR';
+
+		$el_po = new GP_Locale();
+		$el_po->english_name = 'Greek (Polytonic)';
+		$el_po->native_name = 'Greek (Polytonic)'; // TODO.
+		$el_po->country_code = 'gr';
+		$el_po->slug = 'el-po';
 
 		$emoji = new GP_Locale();
 		$emoji->english_name = 'Emoji';
@@ -682,7 +794,7 @@ class GP_Locales {
 		$es_cl->wp_locale = 'es_CL';
 		$es_cl->slug = 'es-cl';
 		$es_cl->google_code = 'es';
-		$es_cl->facebook_locale = 'es_CL';
+		$es_cl->facebook_locale = 'es_LA';
 
 		$es_co = new GP_Locale();
 		$es_co->english_name = 'Spanish (Colombia)';
@@ -694,7 +806,7 @@ class GP_Locales {
 		$es_co->wp_locale = 'es_CO';
 		$es_co->slug = 'es-co';
 		$es_co->google_code = 'es';
-		$es_co->facebook_locale = 'es_CO';
+		$es_co->facebook_locale = 'es_LA';
 
 		$es_cr = new GP_Locale();
 		$es_cr->english_name = 'Spanish (Costa Rica)';
@@ -705,6 +817,32 @@ class GP_Locales {
 		$es_cr->country_code = 'cr';
 		$es_cr->wp_locale = 'es_CR';
 		$es_cr->slug = 'es-cr';
+		$es_cr->google_code = 'es';
+		$es_cr->facebook_locale = 'es_LA';
+
+		$es_do = new GP_Locale();
+		$es_do->english_name = 'Spanish (Dominican Republic)';
+		$es_do->native_name = 'Español de República Dominicana';
+		$es_do->lang_code_iso_639_1 = 'es';
+		$es_do->lang_code_iso_639_2 = 'spa';
+		$es_do->lang_code_iso_639_3 = 'spa';
+		$es_do->country_code = 'do';
+		$es_do->wp_locale = 'es_DO';
+		$es_do->slug = 'es-do';
+		$es_do->google_code = 'es';
+		$es_do->facebook_locale = 'es_LA';
+
+		$es_ec = new GP_Locale();
+		$es_ec->english_name = 'Spanish (Ecuador)';
+		$es_ec->native_name = 'Español de Ecuador';
+		$es_ec->lang_code_iso_639_1 = 'es';
+		$es_ec->lang_code_iso_639_2 = 'spa';
+		$es_ec->lang_code_iso_639_3 = 'spa';
+		$es_ec->country_code = 'ec';
+		$es_ec->wp_locale = 'es_EC';
+		$es_ec->slug = 'es-ec';
+		$es_ec->google_code = 'es';
+		$es_ec->facebook_locale = 'es_LA';
 
 		$es_gt = new GP_Locale();
 		$es_gt->english_name = 'Spanish (Guatemala)';
@@ -717,6 +855,18 @@ class GP_Locales {
 		$es_gt->slug = 'es-gt';
 		$es_gt->google_code = 'es';
 		$es_gt->facebook_locale = 'es_LA';
+
+		$es_hn = new GP_Locale();
+		$es_hn->english_name = 'Spanish (Honduras)';
+		$es_hn->native_name = 'Español de Honduras';
+		$es_hn->lang_code_iso_639_1 = 'es';
+		$es_hn->lang_code_iso_639_2 = 'spa';
+		$es_hn->lang_code_iso_639_3 = 'spa';
+		$es_hn->country_code = 'hn';
+		$es_hn->wp_locale = 'es_HN';
+		$es_hn->slug = 'es-hn';
+		$es_hn->google_code = 'es';
+		$es_hn->facebook_locale = 'es_LA';
 
 		$es_mx = new GP_Locale();
 		$es_mx->english_name = 'Spanish (Mexico)';
@@ -763,6 +913,18 @@ class GP_Locales {
 		$es_us->country_code = 'us';
 		$es_us->slug = 'es-us';
 
+		$es_uy = new GP_Locale();
+		$es_uy->english_name = 'Spanish (Uruguay)';
+		$es_uy->native_name = 'Español de Uruguay';
+		$es_uy->lang_code_iso_639_1 = 'es';
+		$es_uy->lang_code_iso_639_2 = 'spa';
+		$es_uy->lang_code_iso_639_3 = 'spa';
+		$es_uy->country_code = 'uy';
+		$es_uy->wp_locale = 'es_UY';
+		$es_uy->slug = 'es-uy';
+		$es_uy->google_code = 'es';
+		$es_uy->facebook_locale = 'es_LA';
+
 		$es_ve = new GP_Locale();
 		$es_ve->english_name = 'Spanish (Venezuela)';
 		$es_ve->native_name = 'Español de Venezuela';
@@ -773,7 +935,7 @@ class GP_Locales {
 		$es_ve->wp_locale = 'es_VE';
 		$es_ve->slug = 'es-ve';
 		$es_ve->google_code = 'es';
-		$es_ve->facebook_locale = 'es_VE';
+		$es_ve->facebook_locale = 'es_LA';
 
 		$et = new GP_Locale();
 		$et->english_name = 'Estonian';
@@ -830,7 +992,6 @@ class GP_Locales {
 		$ff_sn->country_code = 'sn';
 		$ff_sn->wp_locale = 'fuc';
 		$ff_sn->slug = 'fuc';
-		$ff_sn->plural_expression = 'n!=1';
 
 		$fi = new GP_Locale();
 		$fi->english_name = 'Finnish';
@@ -861,6 +1022,15 @@ class GP_Locales {
 		$fo->slug = 'fo';
 		$fo->facebook_locale = 'fo_FO';
 
+		$fon = new GP_Locale();
+		$fon->english_name = 'Fon';
+		$fon->native_name = 'fɔ̀ngbè';
+		$fon->lang_code_iso_639_2 = 'fon';
+		$fon->lang_code_iso_639_3 = 'fon';
+		$fon->country_code = 'bj';
+		$fon->wp_locale = 'fon';
+		$fon->slug = 'fon';
+
 		$fr = new GP_Locale();
 		$fr->english_name = 'French (France)';
 		$fr->native_name = 'Français';
@@ -881,6 +1051,8 @@ class GP_Locales {
 		$fr_be->country_code = 'be';
 		$fr_be->wp_locale = 'fr_BE';
 		$fr_be->slug = 'fr-be';
+		$fr_be->nplurals = 2;
+		$fr_be->plural_expression = 'n > 1';
 
 		$fr_ca = new GP_Locale();
 		$fr_ca->english_name = 'French (Canada)';
@@ -890,6 +1062,8 @@ class GP_Locales {
 		$fr_ca->country_code = 'ca';
 		$fr_ca->wp_locale = 'fr_CA';
 		$fr_ca->slug = 'fr-ca';
+		$fr_ca->nplurals = 2;
+		$fr_ca->plural_expression = 'n > 1';
 		$fr_ca->facebook_locale = 'fr_CA';
 
 		$fr_ch = new GP_Locale();
@@ -899,6 +1073,8 @@ class GP_Locales {
 		$fr_ch->lang_code_iso_639_2 = 'fra';
 		$fr_ch->country_code = 'ch';
 		$fr_ch->slug = 'fr-ch';
+		$fr_ch->nplurals = 2;
+		$fr_ch->plural_expression = 'n > 1';
 
 		$frp = new GP_Locale();
 		$frp->english_name = 'Arpitan';
@@ -909,6 +1085,16 @@ class GP_Locales {
 		$frp->slug = 'frp';
 		$frp->nplurals = 2;
 		$frp->plural_expression = 'n > 1';
+
+		$ful = new GP_Locale();
+		$ful->english_name = 'Fula';
+		$ful->native_name = 'Fulfulde';
+		$ful->lang_code_iso_639_1 = 'ff';
+		$ful->lang_code_iso_639_2 = 'ful';
+		$ful->lang_code_iso_639_3 = 'ful';
+		$ful->country_code = 'ng';
+		$ful->slug = 'ful';
+		$ful->facebook_locale = 'ff_NG';
 
 		$fur = new GP_Locale();
 		$fur->english_name = 'Friulian';
@@ -938,9 +1124,19 @@ class GP_Locales {
 		$ga->slug = 'ga';
 		$ga->wp_locale = 'ga';
 		$ga->nplurals = 5;
-		$ga->plural_expression = 'n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4';
+		$ga->plural_expression = '(n == 1) ? 0 : ((n == 2) ? 1 : ((n >= 3 && n <= 6) ? 2 : ((n >= 7 && n <= 10) ? 3 : 4)))';
 		$ga->google_code = 'ga';
 		$ga->facebook_locale = 'ga_IE';
+
+		$gax = new GP_Locale();
+		$gax->english_name = 'Borana-Arsi-Guji Oromo';
+		$gax->native_name = 'Afaan Oromoo';
+		$gax->lang_code_iso_639_3 = 'gax';
+		$gax->country_code = 'et';
+		$gax->slug = 'gax';
+		$gax->wp_locale = 'gax';
+		$gax->nplurals = 2;
+		$gax->plural_expression = 'n > 1';
 
 		$gd = new GP_Locale();
 		$gd->english_name = 'Scottish Gaelic';
@@ -952,7 +1148,7 @@ class GP_Locales {
 		$gd->wp_locale = 'gd';
 		$gd->slug = 'gd';
 		$gd->nplurals = 4;
-		$gd->plural_expression = '(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3';
+		$gd->plural_expression = '(n == 1 || n == 11) ? 0 : ((n == 2 || n == 12) ? 1 : ((n >= 3 && n <= 10 || n >= 13 && n <= 19) ? 2 : 3))';
 		$gd->google_code = 'gd';
 
 		$gl = new GP_Locale();
@@ -971,7 +1167,6 @@ class GP_Locales {
 		$gn->native_name = 'Avañe\'ẽ';
 		$gn->lang_code_iso_639_1 = 'gn';
 		$gn->lang_code_iso_639_2 = 'grn';
-		$gn->wp_locale = 'gn';
 		$gn->slug = 'gn';
 
 		$gsw = new GP_Locale();
@@ -980,7 +1175,6 @@ class GP_Locales {
 		$gsw->lang_code_iso_639_2 = 'gsw';
 		$gsw->lang_code_iso_639_3 = 'gsw';
 		$gsw->country_code = 'ch';
-		$gsw->wp_locale = 'gsw';
 		$gsw->slug = 'gsw';
 
 		$gu = new GP_Locale();
@@ -1072,9 +1266,20 @@ class GP_Locales {
 		$hr->wp_locale = 'hr';
 		$hr->slug = 'hr';
 		$hr->nplurals = 3;
-		$hr->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$hr->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$hr->google_code = 'hr';
 		$hr->facebook_locale = 'hr_HR';
+
+		$hsb = new GP_Locale();
+		$hsb->english_name = 'Upper Sorbian';
+		$hsb->native_name = 'Hornjoserbšćina';
+		$hsb->lang_code_iso_639_2 = 'hsb';
+		$hsb->lang_code_iso_639_3 = 'hsb';
+		$hsb->country_code = 'de';
+		$hsb->wp_locale = 'hsb';
+		$hsb->slug = 'hsb';
+		$hsb->nplurals = 4;
+		$hsb->plural_expression = '(n % 100 == 1) ? 0 : ((n % 100 == 2) ? 1 : ((n % 100 == 3 || n % 100 == 4) ? 2 : 3))';
 
 		$hu = new GP_Locale();
 		$hu->english_name = 'Hungarian';
@@ -1105,6 +1310,19 @@ class GP_Locales {
 		$ia->lang_code_iso_639_2 = 'ina';
 		$ia->slug = 'ia';
 
+		$ibo = new GP_Locale();
+		$ibo->english_name = 'Igbo';
+		$ibo->native_name = 'Asụsụ Igbo';
+		$ibo->lang_code_iso_639_1 = 'ig';
+		$ibo->lang_code_iso_639_2 = 'ibo';
+		$ibo->lang_code_iso_639_3 = 'ibo';
+		$ibo->country_code = 'ng';
+		$ibo->wp_locale = 'ibo';
+		$ibo->slug = 'ibo';
+		$ibo->nplurals = 1;
+		$ibo->plural_expression = '0';
+		$ibo->google_code = 'ig';
+
 		$id = new GP_Locale();
 		$id->english_name = 'Indonesian';
 		$id->native_name = 'Bahasa Indonesia';
@@ -1134,6 +1352,8 @@ class GP_Locales {
 		$ike->lang_code_iso_639_2 = 'iku';
 		$ike->country_code = 'ca';
 		$ike->slug = 'ike';
+		$ike->nplurals = 3;
+		$ike->plural_expression = '(n == 1) ? 0 : ((n == 2) ? 1 : 2)';
 
 		$ilo = new GP_Locale();
 		$ilo->english_name = 'Iloko';
@@ -1151,7 +1371,7 @@ class GP_Locales {
 		$is->slug = 'is';
 		$is->wp_locale = 'is_IS';
 		$is->nplurals = 2;
-		$is->plural_expression = '(n % 100 != 1 && n % 100 != 21 && n % 100 != 31 && n % 100 != 41 && n % 100 != 51 && n % 100 != 61 && n % 100 != 71 && n % 100 != 81 && n % 100 != 91)';
+		$is->plural_expression = 'n % 10 != 1 || n % 100 == 11';
 		$is->google_code = 'is';
 		$is->facebook_locale = 'is_IS';
 
@@ -1202,6 +1422,15 @@ class GP_Locales {
 		$ka->google_code = 'ka';
 		$ka->facebook_locale = 'ka_GE';
 
+		$kaa = new GP_Locale();
+		$kaa->english_name = 'Karakalpak';
+		$kaa->native_name = 'Qaraqalpaq tili';
+		$kaa->lang_code_iso_639_2 = 'kaa';
+		$kaa->lang_code_iso_639_3 = 'kaa';
+		$kaa->country_code = 'uz';
+		$kaa->wp_locale = 'kaa';
+		$kaa->slug = 'kaa';
+
 		$kab = new GP_Locale();
 		$kab->english_name = 'Kabyle';
 		$kab->native_name = 'Taqbaylit';
@@ -1211,7 +1440,7 @@ class GP_Locales {
 		$kab->wp_locale = 'kab';
 		$kab->slug = 'kab';
 		$kab->nplurals = 2;
-		$kab->plural_expression = '(n > 1)';
+		$kab->plural_expression = 'n > 1';
 
 		$kal = new GP_Locale();
 		$kal->english_name = 'Greenlandic';
@@ -1264,6 +1493,7 @@ class GP_Locales {
 		$kmr->lang_code_iso_639_1 = 'ku';
 		$kmr->lang_code_iso_639_3 = 'kmr';
 		$kmr->country_code = 'tr';
+		$kmr->wp_locale = 'kmr';
 		$kmr->slug = 'kmr';
 		$kmr->facebook_locale = 'ku_TR';
 
@@ -1339,6 +1569,14 @@ class GP_Locales {
 		$li->slug = 'li';
 		$li->facebook_locale = 'li_NL';
 
+		$lij = new GP_Locale();
+		$lij->english_name = 'Ligurian';
+		$lij->native_name = 'Lìgure';
+		$lij->lang_code_iso_639_3 = 'lij';
+		$lij->country_code = 'it';
+		$lij->wp_locale = 'lij';
+		$lij->slug = 'lij';
+
 		$lin = new GP_Locale();
 		$lin->english_name = 'Lingala';
 		$lin->native_name = 'Ngala';
@@ -1348,7 +1586,7 @@ class GP_Locales {
 		$lin->wp_locale = 'lin';
 		$lin->slug = 'lin';
 		$lin->nplurals = 2;
-		$lin->plural_expression = 'n>1';
+		$lin->plural_expression = 'n > 1';
 		$lin->facebook_locale = 'ln_CD';
 
 		$lmo = new GP_Locale();
@@ -1364,7 +1602,7 @@ class GP_Locales {
 		$lo->native_name = 'ພາສາລາວ';
 		$lo->lang_code_iso_639_1 = 'lo';
 		$lo->lang_code_iso_639_2 = 'lao';
-		$lo->country_code = 'LA';
+		$lo->country_code = 'la';
 		$lo->wp_locale = 'lo';
 		$lo->slug = 'lo';
 		$lo->nplurals = 1;
@@ -1381,7 +1619,7 @@ class GP_Locales {
 		$lt->wp_locale = 'lt_LT';
 		$lt->slug = 'lt';
 		$lt->nplurals = 3;
-		$lt->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$lt->plural_expression = '(n % 10 == 1 && (n % 100 < 11 || n % 100 > 19)) ? 0 : ((n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19)) ? 1 : 2)';
 		$lt->google_code = 'lt';
 		$lt->facebook_locale = 'lt_LT';
 
@@ -1404,9 +1642,18 @@ class GP_Locales {
 		$lv->wp_locale = 'lv';
 		$lv->slug = 'lv';
 		$lv->nplurals = 3;
-		$lv->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)';
+		$lv->plural_expression = '(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2)';
 		$lv->google_code = 'lv';
 		$lv->facebook_locale = 'lv_LV';
+
+		$mai = new GP_Locale();
+		$mai->english_name = 'Maithili';
+		$mai->native_name = 'मैथिली';
+		$mai->lang_code_iso_639_2 = 'mai';
+		$mai->lang_code_iso_639_3 = 'mai';
+		$mai->country_code = 'in';
+		$mai->wp_locale = 'mai';
+		$mai->slug = 'mai';
 
 		$me = new GP_Locale();
 		$me->english_name = 'Montenegrin';
@@ -1454,7 +1701,7 @@ class GP_Locales {
 		$mk->wp_locale = 'mk_MK';
 		$mk->slug = 'mk';
 		$mk->nplurals = 2;
-		$mk->plural_expression = 'n==1 || n%10==1 ? 0 : 1';
+		$mk->plural_expression = 'n % 10 != 1 || n % 100 == 11';
 		$mk->google_code = 'mk';
 		$mk->facebook_locale = 'mk_MK';
 
@@ -1479,7 +1726,7 @@ class GP_Locales {
 		$mlt->wp_locale = 'mlt';
 		$mlt->slug = 'mlt';
 		$mlt->nplurals = 4;
-		$mlt->plural_expression = '(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3)';
+		$mlt->plural_expression = '(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 10) ? 1 : ((n % 100 >= 11 && n % 100 <= 19) ? 2 : 3))';
 		$mlt->google_code = 'mt';
 		$mlt->facebook_locale = 'mt_MT';
 
@@ -1513,7 +1760,7 @@ class GP_Locales {
 		$mri->slug = 'mri';
 		$mri->wp_locale = 'mri';
 		$mri->nplurals = 2;
-		$mri->plural_expression = '(n > 1)';
+		$mri->plural_expression = 'n > 1';
 		$mri->google_code = 'mi';
 
 		$mrj = new GP_Locale();
@@ -1584,6 +1831,13 @@ class GP_Locales {
 		$nl->google_code = 'nl';
 		$nl->facebook_locale = 'nl_NL';
 
+		$nl_formal = clone $nl;
+		$nl_formal->english_name = 'Dutch (Formal)';
+		$nl_formal->native_name = 'Nederlands (Formeel)';
+		$nl_formal->slug = 'nl/formal';
+		$nl_formal->wp_locale = 'nl_NL_formal';
+		$nl_formal->root_slug = $nl->slug;
+
 		$nl_be = new GP_Locale();
 		$nl_be->english_name = 'Dutch (Belgium)';
 		$nl_be->native_name = 'Nederlands (België)';
@@ -1593,6 +1847,15 @@ class GP_Locales {
 		$nl_be->wp_locale = 'nl_BE';
 		$nl_be->slug = 'nl-be';
 		$nl_be->google_code = 'nl';
+
+		$no = new GP_Locale();
+		$no->english_name = 'Norwegian';
+		$no->native_name = 'Norsk';
+		$no->lang_code_iso_639_1 = 'no';
+		$no->lang_code_iso_639_2 = 'nor';
+		$no->country_code = 'no';
+		$no->slug = 'no';
+		$no->google_code = 'no';
 
 		$nn = new GP_Locale();
 		$nn->english_name = 'Norwegian (Nynorsk)';
@@ -1605,14 +1868,23 @@ class GP_Locales {
 		$nn->google_code = 'no';
 		$nn->facebook_locale = 'nn_NO';
 
-		$no = new GP_Locale();
-		$no->english_name = 'Norwegian';
-		$no->native_name = 'Norsk';
-		$no->lang_code_iso_639_1 = 'no';
-		$no->lang_code_iso_639_2 = 'nor';
-		$no->country_code = 'no';
-		$no->slug = 'no';
-		$no->google_code = 'no';
+		$nqo = new GP_Locale();
+		$nqo->english_name = 'N’ko';
+		$nqo->native_name = 'ߒߞߏ';
+		$nqo->lang_code_iso_639_2 = 'nqo';
+		$nqo->lang_code_iso_639_3 = 'nqo';
+		$nqo->country_code = 'gn';
+		$nqo->wp_locale = 'nqo';
+		$nqo->slug = 'nqo';
+		$nqo->text_direction = 'rtl';
+
+		$nso = new GP_Locale();
+		$nso->english_name = 'Northern Sotho';
+		$nso->native_name = 'Sesotho sa Leboa';
+		$nso->lang_code_iso_639_2 = 'nso';
+		$nso->lang_code_iso_639_3 = 'nso';
+		$nso->country_code = 'za';
+		$nso->slug = 'nso';
 
 		$oci = new GP_Locale();
 		$oci->english_name = 'Occitan';
@@ -1623,7 +1895,7 @@ class GP_Locales {
 		$oci->wp_locale = 'oci';
 		$oci->slug = 'oci';
 		$oci->nplurals = 2;
-		$oci->plural_expression = '(n > 1)';
+		$oci->plural_expression = 'n > 1';
 
 		$orm = new GP_Locale();
 		$orm->english_name = 'Oromo';
@@ -1632,7 +1904,7 @@ class GP_Locales {
 		$orm->lang_code_iso_639_2 = 'orm';
 		$orm->lang_code_iso_639_3 = 'orm';
 		$orm->slug = 'orm';
-		$orm->plural_expression = '(n > 1)';
+		$orm->plural_expression = 'n > 1';
 
 		$ory = new GP_Locale();
 		$ory->english_name = 'Oriya';
@@ -1663,14 +1935,41 @@ class GP_Locales {
 		$pa->google_code = 'pa';
 		$pa->facebook_locale = 'pa_IN';
 
-		$pap = new GP_Locale();
-		$pap->english_name = 'Papiamento';
-		$pap->native_name = 'Papiamentu';
-		$pap->lang_code_iso_639_2 = 'pap';
-		$pap->lang_code_iso_639_3 = 'pap';
-		$pap->country_code = 'cw';
-		$pap->wp_locale = 'pap';
-		$pap->slug = 'pap';
+		$pap_cw = new GP_Locale();
+		$pap_cw->english_name = 'Papiamento (Curaçao and Bonaire)';
+		$pap_cw->native_name = 'Papiamentu';
+		$pap_cw->lang_code_iso_639_2 = 'pap';
+		$pap_cw->lang_code_iso_639_3 = 'pap';
+		$pap_cw->country_code = 'cw';
+		$pap_cw->wp_locale = 'pap_CW';
+		$pap_cw->slug = 'pap-cw';
+
+		$pap_aw = new GP_Locale();
+		$pap_aw->english_name = 'Papiamento (Aruba)';
+		$pap_aw->native_name = 'Papiamento';
+		$pap_aw->lang_code_iso_639_2 = 'pap';
+		$pap_aw->lang_code_iso_639_3 = 'pap';
+		$pap_aw->country_code = 'aw';
+		$pap_aw->wp_locale = 'pap_AW';
+		$pap_aw->slug = 'pap-aw';
+
+		$pcd = new GP_Locale();
+		$pcd->english_name = 'Picard';
+		$pcd->native_name = 'Ch’ti';
+		$pcd->lang_code_iso_639_3 = 'pcd';
+		$pcd->country_code = 'fr';
+		$pcd->wp_locale = 'pcd';
+		$pcd->slug = 'pcd';
+		$pcd->nplurals = 2;
+		$pcd->plural_expression = 'n > 1';
+
+		$pcm = new GP_Locale();
+		$pcm->english_name = 'Nigerian Pidgin';
+		$pcm->native_name = 'Nigerian Pidgin';
+		$pcm->lang_code_iso_639_3 = 'pcm';
+		$pcm->country_code = 'ng';
+		$pcm->wp_locale = 'pcm';
+		$pcm->slug = 'pcm';
 
 		$pirate = new GP_Locale();
 		$pirate->english_name = 'English (Pirate)';
@@ -1690,22 +1989,9 @@ class GP_Locales {
 		$pl->wp_locale = 'pl_PL';
 		$pl->slug = 'pl';
 		$pl->nplurals = 3;
-		$pl->plural_expression = '(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$pl->plural_expression = '(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$pl->google_code = 'pl';
 		$pl->facebook_locale = 'pl_PL';
-
-		$pt_br = new GP_Locale();
-		$pt_br->english_name = 'Portuguese (Brazil)';
-		$pt_br->native_name = 'Português do Brasil';
-		$pt_br->lang_code_iso_639_1 = 'pt';
-		$pt_br->lang_code_iso_639_2 = 'por';
-		$pt_br->country_code = 'br';
-		$pt_br->wp_locale = 'pt_BR';
-		$pt_br->slug = 'pt-br';
-		$pt_br->nplurals = 2;
-		$pt_br->plural_expression = '(n > 1)';
-		$pt_br->google_code = 'pt-BR';
-		$pt_br->facebook_locale = 'pt_BR';
 
 		$pt = new GP_Locale();
 		$pt->english_name = 'Portuguese (Portugal)';
@@ -1716,6 +2002,34 @@ class GP_Locales {
 		$pt->slug = 'pt';
 		$pt->google_code = 'pt-PT';
 		$pt->facebook_locale = 'pt_PT';
+
+		$pt_ao90 = clone $pt;
+		$pt_ao90->english_name = 'Portuguese (Portugal, AO90)';
+		$pt_ao90->native_name = 'Português (AO90)';
+		$pt_ao90->slug = 'pt/ao90';
+		$pt_ao90->wp_locale = 'pt_PT_ao90';
+		$pt_ao90->root_slug = $pt->slug;
+
+		$pt_ao = new GP_Locale();
+		$pt_ao->english_name = 'Portuguese (Angola)';
+		$pt_ao->native_name = 'Português de Angola';
+		$pt_ao->lang_code_iso_639_1 = 'pt';
+		$pt_ao->country_code = 'ao';
+		$pt_ao->wp_locale = 'pt_AO';
+		$pt_ao->slug = 'pt-ao';
+
+		$pt_br = new GP_Locale();
+		$pt_br->english_name = 'Portuguese (Brazil)';
+		$pt_br->native_name = 'Português do Brasil';
+		$pt_br->lang_code_iso_639_1 = 'pt';
+		$pt_br->lang_code_iso_639_2 = 'por';
+		$pt_br->country_code = 'br';
+		$pt_br->wp_locale = 'pt_BR';
+		$pt_br->slug = 'pt-br';
+		$pt_br->nplurals = 2;
+		$pt_br->plural_expression = 'n > 1';
+		$pt_br->google_code = 'pt-BR';
+		$pt_br->facebook_locale = 'pt_BR';
 
 		$ps = new GP_Locale();
 		$ps->english_name = 'Pashto';
@@ -1747,14 +2061,15 @@ class GP_Locales {
 		$ro->wp_locale = 'ro_RO';
 		$ro->slug = 'ro';
 		$ro->nplurals = 3;
-		$ro->plural_expression = '(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2)';
+		$ro->plural_expression = '(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 19) ? 1 : 2)';
 		$ro->google_code = 'ro';
 		$ro->facebook_locale = 'ro_RO';
 
 		$roh = new GP_Locale();
 		$roh->english_name = 'Romansh';
 		$roh->native_name = 'Rumantsch';
-		$roh->lang_code_iso_639_2 = 'rm';
+		$roh->lang_code_iso_639_1 = 'rm';
+		$roh->lang_code_iso_639_2 = 'roh';
 		$roh->lang_code_iso_639_3 = 'roh';
 		$roh->country_code = 'ch';
 		$roh->wp_locale = 'roh';
@@ -1769,7 +2084,7 @@ class GP_Locales {
 		$ru->wp_locale = 'ru_RU';
 		$ru->slug = 'ru';
 		$ru->nplurals = 3;
-		$ru->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$ru->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$ru->google_code = 'ru';
 		$ru->facebook_locale = 'ru_RU';
 
@@ -1777,10 +2092,9 @@ class GP_Locales {
 		$rue->english_name = 'Rusyn';
 		$rue->native_name = 'Русиньскый';
 		$rue->lang_code_iso_639_3 = 'rue';
-		$rue->wp_locale = 'rue';
 		$rue->slug = 'rue';
 		$rue->nplurals = 3;
-		$rue->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$rue->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 
 		$rup = new GP_Locale();
 		$rup->english_name = 'Aromanian';
@@ -1788,7 +2102,6 @@ class GP_Locales {
 		$rup->lang_code_iso_639_2 = 'rup';
 		$rup->lang_code_iso_639_3 = 'rup';
 		$rup->country_code = 'mk';
-		$rup->wp_locale = 'rup_MK';
 		$rup->slug = 'rup';
 
 		$sah = new GP_Locale();
@@ -1839,7 +2152,7 @@ class GP_Locales {
 		$sk->slug = 'sk';
 		$sk->wp_locale = 'sk_SK';
 		$sk->nplurals = 3;
-		$sk->plural_expression = '(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2';
+		$sk->plural_expression = '(n == 1) ? 0 : ((n >= 2 && n <= 4) ? 1 : 2)';
 		$sk->google_code = 'sk';
 		$sk->facebook_locale = 'sk_SK';
 
@@ -1851,7 +2164,7 @@ class GP_Locales {
 		$skr->wp_locale = 'skr';
 		$skr->slug = 'skr';
 		$skr->nplurals = 2;
-		$skr->plural_expression = '(n > 1)';
+		$skr->plural_expression = 'n > 1';
 		$skr->text_direction = 'rtl';
 
 		$sl = new GP_Locale();
@@ -1863,7 +2176,7 @@ class GP_Locales {
 		$sl->wp_locale = 'sl_SI';
 		$sl->slug = 'sl';
 		$sl->nplurals = 4;
-		$sl->plural_expression = '(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3)';
+		$sl->plural_expression = '(n % 100 == 1) ? 0 : ((n % 100 == 2) ? 1 : ((n % 100 == 3 || n % 100 == 4) ? 2 : 3))';
 		$sl->google_code = 'sl';
 		$sl->facebook_locale = 'sl_SI';
 
@@ -1880,7 +2193,7 @@ class GP_Locales {
 		$snd->english_name = 'Sindhi';
 		$snd->native_name = 'سنڌي';
 		$snd->lang_code_iso_639_1 = 'sd';
-		$snd->lang_code_iso_639_2 = 'sd';
+		$snd->lang_code_iso_639_2 = 'snd';
 		$snd->lang_code_iso_639_3 = 'snd';
 		$snd->country_code = 'pk';
 		$snd->wp_locale = 'snd';
@@ -1927,7 +2240,7 @@ class GP_Locales {
 		$sr->wp_locale = 'sr_RS';
 		$sr->slug = 'sr';
 		$sr->nplurals = 3;
-		$sr->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$sr->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$sr->google_code = 'sr';
 		$sr->facebook_locale = 'sr_RS';
 
@@ -2030,11 +2343,11 @@ class GP_Locales {
 		$tah->lang_code_iso_639_1 = 'ty';
 		$tah->lang_code_iso_639_2 = 'tah';
 		$tah->lang_code_iso_639_3 = 'tah';
-		$tah->country_code = 'fr';
+		$tah->country_code = 'pf';
 		$tah->wp_locale = 'tah';
 		$tah->slug = 'tah';
 		$tah->nplurals = 2;
-		$tah->plural_expression = '(n > 1)';
+		$tah->plural_expression = 'n > 1';
 
 		$te = new GP_Locale();
 		$te->english_name = 'Telugu';
@@ -2051,7 +2364,7 @@ class GP_Locales {
 		$tg->native_name = 'Тоҷикӣ';
 		$tg->lang_code_iso_639_1 = 'tg';
 		$tg->lang_code_iso_639_2 = 'tgk';
-		$tah->country_code = 'tj';
+		$tg->country_code = 'tj';
 		$tg->wp_locale = 'tg';
 		$tg->slug = 'tg';
 		$tg->google_code = 'tg';
@@ -2109,7 +2422,7 @@ class GP_Locales {
 		$tr->wp_locale = 'tr_TR';
 		$tr->slug = 'tr';
 		$tr->nplurals = 2;
-		$tr->plural_expression = '(n > 1)';
+		$tr->plural_expression = 'n > 1';
 		$tr->google_code = 'tr';
 		$tr->facebook_locale = 'tr_TR';
 
@@ -2134,7 +2447,7 @@ class GP_Locales {
 		$tuk->wp_locale = 'tuk';
 		$tuk->slug = 'tuk';
 		$tuk->nplurals = 2;
-		$tuk->plural_expression = '(n > 1)';
+		$tuk->plural_expression = 'n > 1';
 		$tuk->facebook_locale = 'tk_TM';
 
 		$twd = new GP_Locale();
@@ -2153,7 +2466,7 @@ class GP_Locales {
 		$tzm->wp_locale = 'tzm';
 		$tzm->slug = 'tzm';
 		$tzm->nplurals = 2;
-		$tzm->plural_expression = '(n > 1)';
+		$tzm->plural_expression = 'n > 1';
 
 		$udm = new GP_Locale();
 		$udm->english_name = 'Udmurt';
@@ -2180,7 +2493,7 @@ class GP_Locales {
 		$uk->wp_locale = 'uk';
 		$uk->slug = 'uk';
 		$uk->nplurals = 3;
-		$uk->plural_expression = '(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)';
+		$uk->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$uk->google_code = 'uk';
 		$uk->facebook_locale = 'uk_UA';
 
@@ -2211,11 +2524,12 @@ class GP_Locales {
 
 		$vec = new GP_Locale();
 		$vec->english_name = 'Venetian';
-		$vec->native_name = 'Vèneta';
+		$vec->native_name = 'Vèneto';
 		$vec->lang_code_iso_639_2 = 'roa';
 		$vec->lang_code_iso_639_3 = 'vec';
 		$vec->country_code = 'it';
 		$vec->slug = 'vec';
+		$vec->wp_locale = 'vec';
 
 		$vi = new GP_Locale();
 		$vi->english_name = 'Vietnamese';
@@ -2236,8 +2550,19 @@ class GP_Locales {
 		$wa->lang_code_iso_639_1 = 'wa';
 		$wa->lang_code_iso_639_2 = 'wln';
 		$wa->country_code = 'be';
-		$wa->wp_locale = 'wa';
 		$wa->slug = 'wa';
+
+		$wol = new GP_Locale();
+		$wol->english_name = 'Wolof';
+		$wol->native_name = 'Wolof';
+		$wol->lang_code_iso_639_1 = 'wo';
+		$wol->lang_code_iso_639_2 = 'wol';
+		$wol->lang_code_iso_639_3 = 'wol';
+		$wol->country_code = 'sn';
+		$wol->wp_locale = 'wol';
+		$wol->slug = 'wol';
+		$wol->nplurals = 1;
+		$wol->plural_expression = '0';
 
 		$xho = new GP_Locale();
 		$xho->english_name = 'Xhosa';
@@ -2256,7 +2581,6 @@ class GP_Locales {
 		$xmf->native_name = 'მარგალური ნინა';
 		$xmf->lang_code_iso_639_3 = 'xmf';
 		$xmf->country_code = 'ge';
-		$xmf->wp_locale = 'xmf';
 		$xmf->slug = 'xmf';
 
 		$yi = new GP_Locale();
@@ -2279,6 +2603,26 @@ class GP_Locales {
 		$yor->slug = 'yor';
 		$yor->google_code = 'yo';
 		$yor->facebook_locale = 'yo_NG';
+
+		$zgh = new GP_Locale();
+		$zgh->english_name = 'Tamazight';
+		$zgh->native_name = 'ⵜⴰⵎⴰⵣⵉⵖⵜ';
+		$zgh->lang_code_iso_639_2 = 'zgh';
+		$zgh->lang_code_iso_639_3 = 'zgh';
+		$zgh->country_code = 'ma';
+		$zgh->wp_locale = 'zgh';
+		$zgh->slug = 'zgh';
+		$zgh->nplurals = 2;
+		$zgh->plural_expression = 'n >= 2 && (n < 11 || n > 99)';
+
+		$zh = new GP_Locale();
+		$zh->english_name = 'Chinese';
+		$zh->native_name = '中文';
+		$zh->lang_code_iso_639_1 = 'zh';
+		$zh->lang_code_iso_639_2 = 'zho';
+		$zh->slug = 'zh';
+		$zh->nplurals = 1;
+		$zh->plural_expression = '0';
 
 		$zh_cn = new GP_Locale();
 		$zh_cn->english_name = 'Chinese (China)';
@@ -2329,15 +2673,6 @@ class GP_Locales {
 		$zh_tw->google_code = 'zh-TW';
 		$zh_tw->facebook_locale = 'zh_TW';
 
-		$zh = new GP_Locale();
-		$zh->english_name = 'Chinese';
-		$zh->native_name = '中文';
-		$zh->lang_code_iso_639_1 = 'zh';
-		$zh->lang_code_iso_639_2 = 'zho';
-		$zh->slug = 'zh';
-		$zh->nplurals = 1;
-		$zh->plural_expression = '0';
-
 		$zul = new GP_Locale();
 		$zul->english_name = 'Zulu';
 		$zul->native_name = 'isiZulu';
@@ -2349,7 +2684,7 @@ class GP_Locales {
 		$zul->slug = 'zul';
 		$zul->google_code = 'zu';
 
-		foreach( get_defined_vars() as $locale ) {
+		foreach ( get_defined_vars() as $locale ) {
 			$this->locales[ $locale->slug ] = $locale;
 		}
 	}


### PR DESCRIPTION
This update adds many locales included in the last 2 years, updated plural settings, and Locales names inherited from [GlotPress Locales](https://github.com/GlotPress/GlotPress-WP/blob/develop/locales/locales.php).
The file also includes the currently existent (pseudo) variants from wp.org:
- [x] Dutch (Formal)
- [x] German (Formal)
- [x] German (Switzerland, Informal)
- [x] Portuguese (Portugal, AO90)

The file locales.php is an exact copy from the [wp.org Locales source](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php) for further updates comparison.