### PR TITLE
WPCS: Fix some coding standards checks

### DIFF
--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -32,7 +32,7 @@ class Force_Update_Translations {
 			if ( is_wp_error( $file ) ) {
 				$this->admin_notices[] = array(
 					'status'  => 'error',
-					'content' => $file->get_error_message()
+					'content' => $file->get_error_message(),
 				);
 			}
 		} // endforeach;
@@ -42,7 +42,8 @@ class Force_Update_Translations {
 				'status'  => 'success',
 				'content' => sprintf(
 					__( 'Translation files have been exported: %s', 'force-update-translations' ),
-					'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>' )
+					'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
+				),
 			);
 		}
 		self::admin_notices();

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -127,7 +127,6 @@ class Force_Update_Translations {
 
 	/**
 	 * Prints admin screen notices.
-	 *
 	 */
 	public function admin_notices() {
 		if ( empty( $this->admin_notices ) ) {
@@ -143,4 +142,4 @@ class Force_Update_Translations {
 	}
 }
 
-new Force_Update_Translations;
+new Force_Update_Translations();

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -9,10 +9,10 @@ class Force_Update_Translations {
 
 	public $admin_notices = [];
 
-  function __construct() {
 	/**
 	 * Constructor.
 	 */
+	public function __construct() {
 
 		include 'lib/glotpress/locales.php';
 		include 'inc/plugins.php';
@@ -26,7 +26,7 @@ class Force_Update_Translations {
 	 * @param array $project
 	 * @return null|WP_Error      File path to get source.
 	 */
-	function get_files ( $project ) {
+	public function get_files( $project ) {
 		foreach ( array( 'po', 'mo' ) as $format ) {
 			$file = $this->get_file( $project, get_user_locale(), $format );
 			if ( is_wp_error( $file ) ) {
@@ -56,7 +56,7 @@ class Force_Update_Translations {
 	 * @param string $format    File format
 	 * @return null|WP_Error    File path to get source.
 	 */
-	function get_file( $project, $locale = '', $format = 'mo' ) {
+	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
 		if ( empty( $locale ) ) {
 			$locale = get_user_locale();
@@ -104,7 +104,7 @@ class Force_Update_Translations {
 	 * @param string $format    File format
 	 * @return $path            File path to get source.
 	 */
-	function get_source_path( $project, $locale, $format = 'mo' ) {
+	public function get_source_path( $project, $locale, $format = 'mo' ) {
 		$locale = GP_Locales::by_field( 'wp_locale', $locale );
 
 		// Defaults to 'slug/default' if is a Root Locale, 'slug/variant' if is variant.
@@ -126,7 +126,7 @@ class Force_Update_Translations {
 	 * Prints admin screen notices.
 	 *
 	 */
-	function admin_notices() {
+	public function admin_notices() {
 		if ( empty( $this->admin_notices ) ) {
 			return;
 		}

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -120,7 +120,7 @@ class Force_Update_Translations {
 			$project,
 			$locale_slug
 		);
-		$path = ( $format == 'po' ) ? $path : $path . '&format=' . $format;
+		$path = ( 'po' === $format ) ? $path : $path . '&format=' . $format;
 		$path = esc_url_raw( $path );
 		return $path;
 	}

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -1,11 +1,10 @@
 <?php
-/*
-Plugin Name: Force Update Translations
-Description: Download WordPress theme/plugin translations and apply them to your site manually even if their language pack haven't been released or reviewed on translate.wordpress.org
-Author:      Mayo Moriyama
-Version:     0.3.1
-*/
-
+/**
+ * Plugin Name: Force Update Translations
+ * Description: Download WordPress theme/plugin translations and apply them to your site manually even if their language pack haven't been released or reviewed on translate.wordpress.org
+ * Author:      Mayo Moriyama
+ * Version:     0.3.1
+ */
 class Force_Update_Translations {
 
 	public $admin_notices = [];

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -9,16 +9,16 @@ class Force_Update_Translations {
 
 	public $admin_notices = [];
 
-  /**
-   * Constructor.
-   */
   function __construct() {
+	/**
+	 * Constructor.
+	 */
 
 		include 'lib/glotpress/locales.php';
 		include 'inc/plugins.php';
 		include 'inc/themes.php';
 
-  }
+	}
 
 	/**
 	 * Get translation files.
@@ -27,9 +27,9 @@ class Force_Update_Translations {
 	 * @return null|WP_Error      File path to get source.
 	 */
 	function get_files ( $project ) {
-		foreach ( array( 'po', 'mo' ) as $format ){
+		foreach ( array( 'po', 'mo' ) as $format ) {
 			$file = $this->get_file( $project, get_user_locale(), $format );
-			if( is_wp_error( $file ) ) {
+			if ( is_wp_error( $file ) ) {
 				$this->admin_notices[] = array(
 					'status'  => 'error',
 					'content' => $file->get_error_message()
@@ -68,8 +68,8 @@ class Force_Update_Translations {
 				$project_path = 'wp-' . $target_path . '/dev';
 				break;
 			case 'theme':
-				$target_path  = 'themes/'  . $project['sub_project']['slug'];
-				$project_path = 'wp-'  . $target_path;
+				$target_path  = 'themes/' . $project['sub_project']['slug'];
+				$project_path = 'wp-' . $target_path;
 				break;
 		}
 
@@ -80,9 +80,10 @@ class Force_Update_Translations {
 			$locale,
 			$format
 		);
+
 		$response = wp_remote_get( $source );
 
-		if ( !is_array( $response )
+		if ( ! is_array( $response )
 			|| $response['headers']['content-type'] !== 'application/octet-stream' ) {
 			return new WP_Error( 'fdt-source-not-found', sprintf(
 				__( 'Cannot get source file: %s', 'force-update-translations' ),
@@ -132,7 +133,7 @@ class Force_Update_Translations {
 		foreach ( $this->admin_notices as $notice ) {
 			?>
 			<div class="notice notice-<?php echo esc_attr( $notice['status'] ); ?>">
-					<p><?php echo $notice['content']; // WPCS: XSS OK. ?></p>
+				<p><?php echo $notice['content']; // WPCS: XSS OK. ?></p>
 			</div>
 			<?php
 		}

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -41,6 +41,7 @@ class Force_Update_Translations {
 			$this->admin_notices[] = array(
 				'status'  => 'success',
 				'content' => sprintf(
+					/* translators: %s: Translation file. */
 					__( 'Translation files have been exported: %s', 'force-update-translations' ),
 					'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
 				),
@@ -87,6 +88,7 @@ class Force_Update_Translations {
 		if ( ! is_array( $response )
 			|| $response['headers']['content-type'] !== 'application/octet-stream' ) {
 			return new WP_Error( 'fdt-source-not-found', sprintf(
+				/* translators: %s: Translation file. */
 				__( 'Cannot get source file: %s', 'force-update-translations' ),
 				'<b>' . esc_html( $source ) . '</b>'
 			) );

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -23,7 +23,7 @@ class Force_Update_Translations {
 	/**
 	 * Get translation files.
 	 *
-	 * @param array $project
+	 * @param array $project      Project array.
 	 * @return null|WP_Error      File path to get source.
 	 */
 	public function get_files( $project ) {
@@ -53,10 +53,10 @@ class Force_Update_Translations {
 	/**
 	 * Get translation source file.
 	 *
-	 * @param array  $project   File project
-	 * @param string $locale    File locale
-	 * @param string $format    File format
-	 * @return null|WP_Error    File path to get source.
+	 * @param array  $project   File project.
+	 * @param string $locale    File locale.
+	 * @param string $format    File format.
+	 * @return null|WP_Error    File path to get source..
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 


### PR DESCRIPTION
A first pass on applying WordPress Coding Standards

- [x] Plugin header
- [x] Spacing and indentation fixes
- [x] Methods visibility declaration
- [x] Comments to translators
- [x] Docblock
- [x] Minor fixes