### PR TITLE
create plugin/theme directory in WP translations directory if not exists

### DIFF
--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -94,7 +94,13 @@ class Force_Update_Translations {
 			) );
 		}
 		else {
-			file_put_contents( WP_LANG_DIR . '/' . $target, $response['body'] );
+			$translationPath = WP_LANG_DIR . '/' . $target;
+
+			if ( !file_exists( pathinfo($translationPath,  PATHINFO_DIRNAME ) ) ) {
+				mkdir( pathinfo( $translationPath,  PATHINFO_DIRNAME ), 0777, true );
+			}
+
+			file_put_contents( $translationPath , $response['body'] );
 			return;
 		}
 	}


### PR DESCRIPTION
On fresh WP installation there are no `plugins`/`themes` directory in `WP_LANG_DIR`. When you try to force download translation the fatal error is thrown.

This fix adds check and creates directory if not exists right before storing translation.