### PR TITLE
Improve themes support, with both child and parent themes, updates page title and description

### DIFF
--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -24,22 +24,23 @@ class Force_Update_Translations {
 	/**
 	 * Get translation files.
 	 *
-	 * @param array $project      Project array.
+	 * @param array $projects     Array of translation projects.
 	 * @return null|WP_Error      File path to get source.
 	 */
-	public function get_files( $project ) {
+	public function get_files( $projects ) {
+		foreach ( $projects as $key => $project ) {
 		foreach ( array( 'po', 'mo' ) as $format ) {
 			$file = $this->get_file( $project, get_user_locale(), $format );
 			if ( is_wp_error( $file ) ) {
-				$this->admin_notices[] = array(
+				$this->admin_notices[ $key ][] = array(
 					'status'  => 'error',
 					'content' => $file->get_error_message(),
 				);
 			}
 		} // endforeach;
 
-		if ( empty( $this->admin_notices ) ) {
-			$this->admin_notices[] = array(
+		if ( empty( $this->admin_notices[ $key ] ) ) {
+			$this->admin_notices[ $key ][] = array(
 				'status'  => 'success',
 				'content' => sprintf(
 					/* translators: %s: Translation file. */
@@ -48,6 +49,9 @@ class Force_Update_Translations {
 				),
 			);
 		}
+		}
+
+		// Show admin notices of the projects translation update.
 		self::admin_notices();
 	}
 
@@ -139,12 +143,14 @@ class Force_Update_Translations {
 		if ( empty( $this->admin_notices ) ) {
 			return;
 		}
-		foreach ( $this->admin_notices as $notice ) {
-			?>
-			<div class="notice notice-<?php echo esc_attr( $notice['status'] ); ?>">
-				<p><?php echo $notice['content']; // WPCS: XSS OK. ?></p>
-			</div>
-			<?php
+		foreach ( $this->admin_notices as $project ) {
+			foreach ( $project as $notice ) {
+				?>
+				<div class="notice notice-<?php echo esc_attr( $notice['status'] ); ?>">
+					<p><?php echo $notice['content']; // WPCS: XSS OK. ?></p>
+				</div>
+				<?php
+			}
 		}
 	}
 }

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -8,7 +8,7 @@
  */
 class Force_Update_Translations {
 
-	public $admin_notices = [];
+	public $admin_notices = array();
 
 	/**
 	 * Constructor.
@@ -25,7 +25,8 @@ class Force_Update_Translations {
 	 * Get translation files.
 	 *
 	 * @param array $projects     Array of translation projects.
-	 * @return null|WP_Error      File path to get source.
+	 *
+	 * @return void
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
@@ -61,6 +62,7 @@ class Force_Update_Translations {
 	 * @param array  $project   File project.
 	 * @param string $locale    File locale.
 	 * @param string $format    File format.
+	 *
 	 * @return null|WP_Error    File path to get source..
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
@@ -92,20 +94,22 @@ class Force_Update_Translations {
 
 		if ( ! is_array( $response )
 			|| $response['headers']['content-type'] !== 'application/octet-stream' ) {
-			return new WP_Error( 'fdt-source-not-found', sprintf(
-				/* translators: %s: Translation file. */
-				__( 'Cannot get source file: %s', 'force-update-translations' ),
-				'<b>' . esc_html( $source ) . '</b>'
-			) );
-		}
-		else {
-			$translationPath = WP_LANG_DIR . '/' . $target;
+			return new WP_Error(
+				'fdt-source-not-found',
+				sprintf(
+					/* translators: %s: Translation file. */
+					__( 'Cannot get source file: %s', 'force-update-translations' ),
+					'<b>' . esc_html( $source ) . '</b>'
+				)
+			);
+		} else {
+			$translation_path = WP_LANG_DIR . '/' . $target;
 
-			if ( !file_exists( pathinfo($translationPath,  PATHINFO_DIRNAME ) ) ) {
-				mkdir( pathinfo( $translationPath,  PATHINFO_DIRNAME ), 0777, true );
+			if ( ! file_exists( pathinfo( $translation_path,  PATHINFO_DIRNAME ) ) ) {
+				mkdir( pathinfo( $translation_path, PATHINFO_DIRNAME ), 0777, true );
 			}
 
-			file_put_contents( $translationPath , $response['body'] );
+			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
 			return;
 		}
 	}
@@ -113,9 +117,9 @@ class Force_Update_Translations {
 	/**
 	 * Generate a file path to get translation file.
 	 *
-	 * @param string $project   File project
-	 * @param string $locale    File locale
-	 * @param string $format    File format
+	 * @param string $project   File project.
+	 * @param string $locale    File locale.
+	 * @param string $format    File format.
 	 * @return $path            File path to get source.
 	 */
 	public function get_source_path( $project, $locale, $format = 'mo' ) {
@@ -127,11 +131,12 @@ class Force_Update_Translations {
 			$locale_slug .= '/default';
 		}
 
-		$path = sprintf( 'https://translate.wordpress.org/projects/%1$s/%2$s/export-translations?filters[status]=current_or_waiting_or_fuzzy',
+		$path = sprintf(
+			'https://translate.wordpress.org/projects/%1$s/%2$s/export-translations?filters[status]=current_or_waiting_or_fuzzy',
 			$project,
 			$locale_slug
 		);
-		$path = ( 'po' === $format ) ? $path : $path . '&format=' . $format;
+		$path = ( $format === 'po' ) ? $path : $path . '&format=' . $format;
 		$path = esc_url_raw( $path );
 		return $path;
 	}

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -146,8 +146,8 @@ class Force_Update_Translations {
 		foreach ( $this->admin_notices as $project ) {
 			foreach ( $project as $notice ) {
 				?>
-				<div class="notice notice-<?php echo esc_attr( $notice['status'] ); ?>">
-					<p><?php echo $notice['content']; // WPCS: XSS OK. ?></p>
+				<div class="notice notice-<?php echo esc_attr( $notice['status'] ); ?> inline">
+					<p><?php echo wp_kses_post( $notice['content'] ); ?></p>
 				</div>
 				<?php
 			}

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -29,26 +29,26 @@ class Force_Update_Translations {
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
-		foreach ( array( 'po', 'mo' ) as $format ) {
-			$file = $this->get_file( $project, get_user_locale(), $format );
-			if ( is_wp_error( $file ) ) {
+			foreach ( array( 'po', 'mo' ) as $format ) {
+				$file = $this->get_file( $project, get_user_locale(), $format );
+				if ( is_wp_error( $file ) ) {
+					$this->admin_notices[ $key ][] = array(
+						'status'  => 'error',
+						'content' => $file->get_error_message(),
+					);
+				}
+			} // endforeach;
+
+			if ( empty( $this->admin_notices[ $key ] ) ) {
 				$this->admin_notices[ $key ][] = array(
-					'status'  => 'error',
-					'content' => $file->get_error_message(),
+					'status'  => 'success',
+					'content' => sprintf(
+						/* translators: %s: Translation file. */
+						__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
+						'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
+					),
 				);
 			}
-		} // endforeach;
-
-		if ( empty( $this->admin_notices[ $key ] ) ) {
-			$this->admin_notices[ $key ][] = array(
-				'status'  => 'success',
-				'content' => sprintf(
-					/* translators: %s: Translation file. */
-					__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
-					'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
-				),
-			);
-		}
 		}
 
 		// Show admin notices of the projects translation update.

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -70,7 +70,7 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 
     $plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false );
 
-    $project = array (
+    $projects[ $plugin_file ] = array (
       'type'   => 'plugin',
       'sub_project'  => array(
         'slug' => $plugin_slug[1],
@@ -78,7 +78,7 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
       )
     );
 
-    parent::get_files( $project );
+    parent::get_files( $projects );
 	}
 }
 new Plugin_Force_Update_Translations;

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -7,19 +7,22 @@
 
 class Plugin_Force_Update_Translations extends Force_Update_Translations {
 
-  /**
-   * Constructor.
-   */
-  function __construct() {
-		add_action( 'plugin_action_links',               array( $this, 'plugin_action_links'        ), 10, 2 );
-		add_action( 'network_admin_plugin_action_links', array( $this, 'plugin_action_links'        ), 10, 2 );
-		add_action( 'pre_current_active_plugins',        array( $this, 'pre_current_active_plugins' ) );
-  }
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		add_action( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 );
+		add_action( 'network_admin_plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 );
+		add_action( 'pre_current_active_plugins', array( $this, 'pre_current_active_plugins' ) );
+	}
+
+
 	/**
 	 * Add plugin action link.
 	 *
 	 * @param string $actions
 	 * @param string $plugin_file
+	 *
 	 * @return array $actions    File path to get source.
 	 */
 	function plugin_action_links( $actions, $plugin_file ) {
@@ -29,56 +32,61 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 				'<a href="%1$s">%2$s</a>',
 				esc_url( $url ),
 				esc_html__( 'Update translation', 'force-update-translations' )
-			)
+			),
 		);
-		// Check if plugin is on wordpress.org by checking if ID (from Plugin wp.org info) exists in 'response' or 'no_update'
-		$on_wporg = false;
+
+		// Check if plugin is on wordpress.org by checking if ID (from Plugin wp.org info) exists in 'response' or 'no_update'.
+		$on_wporg     = false;
 		$plugin_state = get_site_transient( 'update_plugins' );
 		if ( isset( $plugin_state->response[ $plugin_file ]->id ) || isset( $plugin_state->no_update[ $plugin_file ]->id ) ) {
 			$on_wporg = true;
 		};
-		// Add action if plugin is on wordpress.org and if user Locale isn't 'en_US'
-		if ( ( $on_wporg ) && ( get_user_locale() != 'en_US' ) ) {
-			$actions  = array_merge( $actions, $new_actions );
+
+		// Add action if plugin is on wordpress.org and if user Locale isn't 'en_US'.
+		if ( ( $on_wporg ) && ( get_user_locale() !== 'en_US' ) ) {
+			$actions = array_merge( $actions, $new_actions );
 		};
 		return $actions;
 
 	}
+
+
 	/**
 	 * Main plugin action.
 	 *
 	 * @return null
 	 */
 	function pre_current_active_plugins() {
-		if ( !isset( $_GET['force_translate'] ) ) {
+		if ( ! isset( $_GET['force_translate'] ) ) {
 			return;
 		}
 
 		$plugin_file = $_GET['force_translate'];
-		if ( !preg_match("/^([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_.]+.php)$/", $plugin_file, $plugin_slug) ){
+		if ( ! preg_match( "/^([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_.]+.php)$/", $plugin_file, $plugin_slug ) ) {
 			$this->admin_notices[] = array(
 				'status'  => 'error',
 				'content' => sprintf(
 					/* Translators: %s: parameter */
 					esc_html__( 'Invalid parameter: %s', 'force-update-translations' ),
 					esc_html( $plugin_file )
-				)
+				),
 			);
 			static::admin_notices();
 			return;
 		}
 
-    $plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false );
+		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false );
 
-    $projects[ $plugin_file ] = array (
-      'type'   => 'plugin',
-      'sub_project'  => array(
-        'slug' => $plugin_slug[1],
-        'name' => $plugin_data['Name']
-      )
-    );
+		$projects[ $plugin_file ] = array(
+			'type'        => 'plugin',
+			'sub_project' => array(
+				'slug' => $plugin_slug[1],
+				'name' => $plugin_data['Name'],
+			),
+		);
 
-    parent::get_files( $projects );
+		parent::get_files( $projects );
 	}
 }
-new Plugin_Force_Update_Translations;
+
+new Plugin_Force_Update_Translations();

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -73,7 +73,17 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
 
 	?>
 	<div class="wrap">
-		<h1><?php esc_html_e( 'Themes Translations', 'force-update-translations' ); ?></h1>
+		<h1><?php esc_html_e( 'Update Translations', 'force-update-translations' ); ?></h1>
+		<p>
+			<?php 
+			// Check if has a parent theme and it exists.
+			if ( $parent_theme && $parent_theme->exists() ) {
+				esc_html_e( 'Translation updates for your active child and parent themes.', 'force-update-translations' );
+			} else {
+				esc_html_e( 'Translation updates for your active theme.', 'force-update-translations' );
+			}
+			?>
+		</p>
 		<div class="update-messages">
 			<?php
 			// Get projects translation files.

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -69,8 +69,17 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
 
     }
 
-    // Get projects translation files.
-    parent::get_files( $projects );
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Themes Translations', 'force-update-translations' ); ?></h1>
+		<div class="update-messages">
+			<?php
+			// Get projects translation files.
+		    parent::get_files( $projects );
+			?>
+		</div>
+	</div>
+	<?php
 
   }
 

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -4,70 +4,72 @@
  * @author mayukojpn
  * @license GPL-2.0+
  */
-
 class Theme_Force_Update_Translations extends Force_Update_Translations {
 
-  /**
-   * Constructor.
-   */
-  function __construct() {
-    // Add theme translation option if user Locale is not 'en_US'.
-    if ( get_user_locale() !== 'en_US' ) {
-      add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-    };
-  }
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		// Add theme translation option if user Locale is not 'en_US'.
+		if ( get_user_locale() !== 'en_US' ) {
+			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+		};
+	}
 
-  /**
-   * Generate theme translation update option.
-   *
-   */
-  function admin_menu() {
-  	$theme_page = add_theme_page(
-  		esc_html__( 'Update translation', 'force-update-translations' ),
-  		esc_html__( 'Update translation', 'force-update-translations' ),
-  		'edit_theme_options',
-  		'force_translate',
-  		array( $this, 'get_theme_translations' )
-  	);
-  }
 
-  function get_theme_translations() {
+	/**
+	 * Generate theme translation update option.
+	 *
+	 */
+	function admin_menu() {
+		$theme_page = add_theme_page(
+			esc_html__( 'Update translation', 'force-update-translations' ),
+			esc_html__( 'Update translation', 'force-update-translations' ),
+			'edit_theme_options',
+			'force_translate',
+			array( $this, 'get_theme_translations' )
+		);
+	}
 
-    // Get current theme data.
-    $current_theme = wp_get_theme();
 
-    // Add current theme.
-    $themes[ $current_theme->get_stylesheet() ] = $current_theme;
+	function get_theme_translations() {
 
-    // Get parent theme data.
-    $parent_theme = $current_theme->parent();
-    // Check if has a parent theme and it exists.
-    if ( $parent_theme && $parent_theme->exists() ) {
-      // Add parent theme.
-      $themes[ $parent_theme->get_stylesheet() ] = $parent_theme;
-    }
+		// Get current theme data.
+		$current_theme = wp_get_theme();
 
-    // Get installed themes update transient.
-    $installed_themes = get_site_transient( 'update_themes' );
+		// Add current theme.
+		$themes[ $current_theme->get_stylesheet() ] = $current_theme;
 
-    $projects = array();
+		// Get parent theme data.
+		$parent_theme = $current_theme->parent();
 
-    foreach ( $themes as $stylesheet => $theme ) {
+		// Check if has a parent theme and it exists.
+		if ( $parent_theme && $parent_theme->exists() ) {
+			// Add parent theme.
+			$themes[ $parent_theme->get_stylesheet() ] = $parent_theme;
+		}
 
-      // Check if theme is on wordpress.org by checking if the stylesheet (from Theme wp.org info) exists in 'response' or 'no_update'.
-      if ( isset( $installed_themes->response[ $theme->get_stylesheet() ] ) || isset( $installed_themes->no_update[ $theme->get_stylesheet() ] ) ) {
+		// Get installed themes update transient.
+		$installed_themes = get_site_transient( 'update_themes' );
 
-        $projects[ $stylesheet ] = array (
-          'type'   => 'theme',
-          'sub_project'  => array(
-            'slug' => $theme->get( 'TextDomain' ),
-            'name' => $theme->get( 'Name' )
-          )
-        );
+		$projects = array();
 
-      };
+		foreach ( $themes as $stylesheet => $theme ) {
 
-    }
+			// Check if theme is on wordpress.org by checking if the stylesheet (from Theme wp.org info) exists in 'response' or 'no_update'.
+			if ( isset( $installed_themes->response[ $theme->get_stylesheet() ] ) || isset( $installed_themes->no_update[ $theme->get_stylesheet() ] ) ) {
+
+				$projects[ $stylesheet ] = array(
+					'type'        => 'theme',
+					'sub_project' => array(
+						'slug' => $theme->get( 'TextDomain' ),
+						'name' => $theme->get( 'Name' ),
+					),
+				);
+
+			};
+
+		}
 
 	?>
 	<div class="wrap">
@@ -75,14 +77,12 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
 		<div class="update-messages">
 			<?php
 			// Get projects translation files.
-		    parent::get_files( $projects );
+			parent::get_files( $projects );
 			?>
 		</div>
 	</div>
 	<?php
-
-  }
-
+	}
 }
+
 new Theme_Force_Update_Translations();
-?>

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -33,14 +33,40 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
     // Get current theme data.
     $current_theme = wp_get_theme();
 
-    $projects[ $current_theme->get_stylesheet() ] = array (
-      'type'   => 'theme',
-      'sub_project'  => array(
-        'slug' => $current_theme->get( 'TextDomain' ),
-        'name' => $current_theme->get( 'Name' )
-      )
-    );
+    // Add current theme.
+    $themes[ $current_theme->get_stylesheet() ] = $current_theme;
 
+    // Get parent theme data.
+    $parent_theme = $current_theme->parent();
+    // Check if has a parent theme and it exists.
+    if ( $parent_theme && $parent_theme->exists() ) {
+      // Add parent theme.
+      $themes[ $parent_theme->get_stylesheet() ] = $parent_theme;
+    }
+
+    // Get installed themes update transient.
+    $installed_themes = get_site_transient( 'update_themes' );
+
+    $projects = array();
+
+    foreach ( $themes as $stylesheet => $theme ) {
+
+      // Check if theme is on wordpress.org by checking if the stylesheet (from Theme wp.org info) exists in 'response' or 'no_update'.
+      if ( isset( $installed_themes->response[ $theme->get_stylesheet() ] ) || isset( $installed_themes->no_update[ $theme->get_stylesheet() ] ) ) {
+
+        $projects[ $stylesheet ] = array (
+          'type'   => 'theme',
+          'sub_project'  => array(
+            'slug' => $theme->get( 'TextDomain' ),
+            'name' => $theme->get( 'Name' )
+          )
+        );
+
+      };
+
+    }
+
+    // Get projects translation files.
     parent::get_files( $projects );
 
   }

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -30,9 +30,10 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
 
   function get_theme_translations() {
 
+    // Get current theme data.
     $current_theme = wp_get_theme();
 
-    $project = array (
+    $projects[ $current_theme->get_stylesheet() ] = array (
       'type'   => 'theme',
       'sub_project'  => array(
         'slug' => $current_theme->get( 'TextDomain' ),
@@ -40,7 +41,7 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
       )
     );
 
-    parent::get_files( $project );
+    parent::get_files( $projects );
 
   }
 

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -11,7 +11,10 @@ class Theme_Force_Update_Translations extends Force_Update_Translations {
    * Constructor.
    */
   function __construct() {
-    add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+    // Add theme translation option if user Locale is not 'en_US'.
+    if ( get_user_locale() !== 'en_US' ) {
+      add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+    };
   }
 
   /**

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mayukojpn, nao, dartui, pedromendonca, casiepa, mekemoke, miyauchi, nekojonez
 Tags: translation
 Requires at least: 4.9
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.2.4
 Stable tag: 0.4.1
 License: GPLv2 or later


### PR DESCRIPTION
This PR checks if the theme exists in WP.org, and if it has parent, if so, download both translation projects, child and parent.
Also only shows the themes translations update if the locale isn't `en_US`, the same logic used in the plugins.

- [x] Check if theme(s) exist in WP.org
- [x] Check if user locale isn't `en_US`
- [x] If the theme is a child theme (has parent), download both parent and child theme translations
- [x] Add a title and description to the theme updates page
- [x] Tested with WP 6.3

Fixes #35 and #42