### PR TITLE
Stable/Development の取得元表示・選択と翻訳アーティファクト生成を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ To download the translation files for a plugin:
 
 ## Changelog
 
+= 0.6.3 - 2026-07-28 =
+* Feature: Choose Stable or Development as the translation source when updating plugin translations
+* Feature: Show whether installed plugin translations came from Stable or Development
+
 = 0.6.0 - 2025-12-17 =
 * Security: Fixed CSRF vulnerability (CVE-2025-58236)
 * Security: Added nonce verification and permission checks for translation updates

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -4,7 +4,7 @@
  * Description: Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
  * Author:      Mayo Moriyama & Contributors
  * Author URI:  https://github.com/mayukojpn/force-update-translations/graphs/contributors
- * Version:     0.6.1
+ * Version:     0.6.2
  * Requires at least: 4.7
  * Requires PHP: 5.6
  * Text Domain: force-update-translations
@@ -23,7 +23,7 @@ class Force_Update_Translations {
 	/**
 	 * Admin notices array.
 	 *
-	 * @var array<string, array<int, array<string, string>>>
+	 * @var array
 	 */
 	public $admin_notices = array();
 
@@ -32,54 +32,70 @@ class Force_Update_Translations {
 	 */
 	public function __construct() {
 
-		include 'lib/glotpress/locales.php';
-		include 'inc/plugins.php';
-		include 'inc/themes.php';
+		include_once __DIR__ . '/lib/glotpress/locales.php';
+		include_once __DIR__ . '/inc/plugins.php';
+		include_once __DIR__ . '/inc/themes.php';
 	}
 
 	/**
 	 * Get translation files.
 	 *
-	 * @param array $projects     Array of translation projects.
+	 * @param array $projects Array of translation projects.
 	 *
 	 * @return void
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
+			$locale = get_user_locale();
+
 			foreach ( array( 'po', 'mo' ) as $format ) {
-				$file = $this->get_file( $project, get_user_locale(), $format );
+				$file = $this->get_file( $project, $locale, $format );
 				if ( is_wp_error( $file ) ) {
 					$this->admin_notices[ $key ][] = array(
 						'status'  => 'error',
 						'content' => $file->get_error_message(),
 					);
 				}
-			} // endforeach;
+			}
 
 			if ( empty( $this->admin_notices[ $key ] ) ) {
-				$this->admin_notices[ $key ][] = array(
-					'status'  => 'success',
-					'content' => sprintf(
-						/* translators: %s: Translation file. */
-						__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
-						'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
-					),
-				);
+				$derived = $this->generate_derived_translation_files( $project, $locale );
+				if ( is_wp_error( $derived ) ) {
+					$this->admin_notices[ $key ][] = array(
+						'status'  => 'error',
+						'content' => $derived->get_error_message(),
+					);
+				} else {
+					$this->admin_notices[ $key ][] = array(
+						'status'  => 'success',
+						'content' => sprintf(
+							/* translators: %s: Translation file. */
+							__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
+							'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
+						),
+					);
+				}
 			}
 		}
 
-		// Show admin notices of the projects translation update.
-		self::admin_notices();
+		// Defer notices until admin_notices when that hook has not yet run
+		// (e.g. plugin updates during admin_init). Print immediately when the
+		// hook already fired (e.g. theme translation settings page callback).
+		if ( ! did_action( 'admin_notices' ) ) {
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+		} else {
+			$this->admin_notices();
+		}
 	}
 
 	/**
 	 * Get translation source file.
 	 *
-	 * @param array  $project   File project.
-	 * @param string $locale    File locale.
-	 * @param string $format    File format.
+	 * @param array  $project File project.
+	 * @param string $locale  File locale.
+	 * @param string $format  File format.
 	 *
-	 * @return null|WP_Error    File path to get source..
+	 * @return null|WP_Error File path to get source.
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
@@ -87,18 +103,24 @@ class Force_Update_Translations {
 			$locale = get_user_locale();
 		}
 
+		$target_path   = '';
+		$project_paths = array();
+
 		switch ( $project['type'] ) {
 			case 'plugin':
-				$target_path  = 'plugins/' . $project['sub_project']['slug'];
-				$project_path = 'wp-' . $target_path . '/dev';
+				$target_path   = 'plugins/' . $project['sub_project']['slug'];
+				// Development first (includes newest / waiting strings), then Stable.
+				$project_paths = array(
+					'wp-' . $target_path . '/dev',
+					'wp-' . $target_path . '/stable',
+				);
 				break;
 			case 'theme':
-				$target_path  = 'themes/' . $project['sub_project']['slug'];
-				$project_path = 'wp-' . $target_path;
+				$target_path   = 'themes/' . $project['sub_project']['slug'];
+				$project_paths = array( 'wp-' . $target_path );
 				break;
 		}
 
-		$source = $this->get_source_path( $project_path, $locale, $format );
 		$target = sprintf(
 			'%s-%s.%s',
 			$target_path,
@@ -106,37 +128,54 @@ class Force_Update_Translations {
 			$format
 		);
 
-		$response = wp_remote_get( $source );
-
-		if ( ! is_array( $response )
-			|| 'application/octet-stream' !== $response['headers']['content-type'] ) {
-			return new WP_Error(
-				'fdt-source-not-found',
-				sprintf(
-					/* translators: %s: Translation file. */
-					__( 'Cannot get source file: %s', 'force-update-translations' ),
-					'<b>' . esc_html( $source ) . '</b>'
+		$last_source = '';
+		foreach ( $project_paths as $project_path ) {
+			$source      = $this->get_source_path( $project_path, $locale, $format );
+			$last_source = $source;
+			$response    = wp_remote_get(
+				$source,
+				array(
+					'timeout' => 60,
 				)
 			);
-		} else {
+
+			$content_type = '';
+			if ( is_array( $response ) && isset( $response['headers']['content-type'] ) ) {
+				$content_type = $response['headers']['content-type'];
+			}
+
+			if ( ! is_array( $response )
+				|| false === strpos( $content_type, 'application/octet-stream' ) ) {
+				continue;
+			}
+
 			$translation_path = WP_LANG_DIR . '/' . $target;
 
 			if ( ! file_exists( pathinfo( $translation_path, PATHINFO_DIRNAME ) ) ) {
 				mkdir( pathinfo( $translation_path, PATHINFO_DIRNAME ), 0777, true );
 			}
 
-            file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
-			return;
+			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
+			return null;
 		}
+
+		return new WP_Error(
+			'fdt-source-not-found',
+			sprintf(
+				/* translators: %s: Translation file. */
+				__( 'Cannot get source file: %s', 'force-update-translations' ),
+				'<b>' . esc_html( $last_source ) . '</b>'
+			)
+		);
 	}
 
 	/**
 	 * Generate a file path to get translation file.
 	 *
-	 * @param string $project   File project.
-	 * @param string $locale    File locale.
-	 * @param string $format    File format.
-	 * @return $path            File path to get source.
+	 * @param string $project File project.
+	 * @param string $locale  File locale.
+	 * @param string $format  File format.
+	 * @return string File path to get source.
 	 */
 	public function get_source_path( $project, $locale, $format = 'mo' ) {
 		$locale = GP_Locales::by_field( 'wp_locale', $locale );
@@ -155,6 +194,198 @@ class Force_Update_Translations {
 		$path = ( 'po' === $format ) ? $path : $path . '&format=' . $format;
 		$path = esc_url_raw( $path );
 		return $path;
+	}
+
+	/**
+	 * Build .json (JS) and .l10n.php files from the downloaded PO/MO.
+	 *
+	 * Modern WordPress loads JS strings from Jed JSON files and prefers
+	 * .l10n.php over .mo for PHP strings. Without these, unapproved
+	 * translations in the PO/MO often appear not to apply.
+	 *
+	 * @param array  $project Project data.
+	 * @param string $locale  Locale.
+	 * @return true|WP_Error
+	 */
+	public function generate_derived_translation_files( $project, $locale ) {
+		$subdir = ( 'theme' === $project['type'] ) ? 'themes' : 'plugins';
+		$slug   = $project['sub_project']['slug'];
+		$base   = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale;
+		$po     = $base . '.po';
+		$mo     = $base . '.mo';
+
+		if ( ! is_readable( $po ) ) {
+			return new WP_Error(
+				'fdt-po-missing',
+				sprintf(
+					/* translators: %s: File path. */
+					__( 'Cannot generate translation artifacts; PO file missing: %s', 'force-update-translations' ),
+					'<b>' . esc_html( $po ) . '</b>'
+				)
+			);
+		}
+
+		$this->delete_existing_json_files( $subdir, $slug, $locale );
+
+		$json_result = $this->make_json_files( $po, dirname( $po ), $slug . '-' . $locale );
+		if ( is_wp_error( $json_result ) ) {
+			return $json_result;
+		}
+
+		if ( is_readable( $mo ) && class_exists( 'WP_Translation_File', false ) ) {
+			$php = WP_Translation_File::transform( $mo, 'php' );
+			if ( is_string( $php ) && '' !== $php ) {
+				file_put_contents( $base . '.l10n.php', $php ); // phpcs:ignore
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Remove previously generated Jed JSON files for a domain/locale.
+	 *
+	 * @param string $subdir plugins or themes.
+	 * @param string $slug   Text domain / slug.
+	 * @param string $locale Locale.
+	 * @return void
+	 */
+	protected function delete_existing_json_files( $subdir, $slug, $locale ) {
+		$pattern = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale . '-*.json';
+		$files   = glob( $pattern );
+		if ( empty( $files ) ) {
+			return;
+		}
+		foreach ( $files as $file ) {
+			unlink( $file ); // phpcs:ignore
+		}
+	}
+
+	/**
+	 * Split a PO file into Jed JSON files (one per JS source file).
+	 *
+	 * @param string $po_file         Path to PO file.
+	 * @param string $destination_dir Destination directory.
+	 * @param string $base_file_name  Filename prefix (domain-locale).
+	 * @return int|WP_Error Number of JSON files created.
+	 */
+	protected function make_json_files( $po_file, $destination_dir, $base_file_name ) {
+		if ( ! class_exists( 'PO', false ) ) {
+			require_once ABSPATH . WPINC . '/pomo/po.php';
+		}
+
+		$po = new PO();
+		if ( ! $po->import_from_file( $po_file ) ) {
+			return new WP_Error(
+				'fdt-po-parse',
+				sprintf(
+					/* translators: %s: File path. */
+					__( 'Could not parse PO file: %s', 'force-update-translations' ),
+					'<b>' . esc_html( $po_file ) . '</b>'
+				)
+			);
+		}
+
+		$js_extensions = array( 'js', 'jsx', 'ts', 'tsx' );
+		$mapping       = array();
+
+		foreach ( $po->entries as $entry ) {
+			if ( empty( $entry->translations ) || '' === $entry->translations[0] ) {
+				continue;
+			}
+
+			$sources = array();
+			foreach ( (array) $entry->references as $reference ) {
+				$file = $reference;
+				if ( preg_match( '/^(.+):(\d+)$/', $reference, $matches ) ) {
+					$file = $matches[1];
+				}
+
+				$extension = pathinfo( $file, PATHINFO_EXTENSION );
+				if ( ! in_array( $extension, $js_extensions, true ) ) {
+					continue;
+				}
+
+				// Normalize foo.min.js -> foo.js (matches wp i18n make-json).
+				$file      = preg_replace( '/\.min\.' . preg_quote( $extension, '/' ) . '$/', '.' . $extension, $file );
+				$sources[] = $file;
+			}
+
+			$sources = array_unique( $sources );
+			foreach ( $sources as $source ) {
+				if ( ! isset( $mapping[ $source ] ) ) {
+					$mapping[ $source ] = array();
+				}
+				$mapping[ $source ][] = $entry;
+			}
+		}
+
+		$created = 0;
+		foreach ( $mapping as $source => $entries ) {
+			$jed = $this->build_jed_json( $po, $entries, $source );
+			$file = $destination_dir . '/' . $base_file_name . '-' . md5( $source ) . '.json';
+			$json = wp_json_encode( $jed );
+			if ( false === $json ) {
+				continue;
+			}
+			file_put_contents( $file, $json ); // phpcs:ignore
+			++$created;
+		}
+
+		return $created;
+	}
+
+	/**
+	 * Build a Jed 1.x compatible data structure for script translations.
+	 *
+	 * @param PO                 $po      Parsed PO (for headers).
+	 * @param Translation_Entry[] $entries Entries for one JS source file.
+	 * @param string             $source  Relative JS source path.
+	 * @return array
+	 */
+	protected function build_jed_json( $po, $entries, $source ) {
+		$lang         = isset( $po->headers['Language'] ) ? $po->headers['Language'] : '';
+		$plural_forms = isset( $po->headers['Plural-Forms'] ) ? $po->headers['Plural-Forms'] : 'nplurals=2; plural=n != 1;';
+		$revision     = isset( $po->headers['PO-Revision-Date'] ) ? $po->headers['PO-Revision-Date'] : '';
+
+		$messages = array(
+			'' => array(
+				'domain'       => 'messages',
+				'lang'         => $lang,
+				'plural-forms' => $plural_forms,
+			),
+		);
+
+		foreach ( $entries as $entry ) {
+			$key = $entry->singular;
+			if ( ! empty( $entry->context ) ) {
+				$key = $entry->context . "\4" . $entry->singular;
+			}
+			$messages[ $key ] = array_values( $entry->translations );
+		}
+
+		return array(
+			'translation-revision-date' => $revision,
+			'generator'                 => 'Force Update Translations/' . $this->get_plugin_version(),
+			'source'                    => $source,
+			'domain'                    => 'messages',
+			'locale_data'               => array(
+				'messages' => $messages,
+			),
+		);
+	}
+
+	/**
+	 * Plugin version from the main file header.
+	 *
+	 * @return string
+	 */
+	protected function get_plugin_version() {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$data = get_plugin_data( __FILE__, false, false );
+		return isset( $data['Version'] ) ? $data['Version'] : '0.6.2';
 	}
 
 	/**

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -4,7 +4,7 @@
  * Description: Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
  * Author:      Mayo Moriyama & Contributors
  * Author URI:  https://github.com/mayukojpn/force-update-translations/graphs/contributors
- * Version:     0.6.2
+ * Version:     0.6.3
  * Requires at least: 4.7
  * Requires PHP: 5.6
  * Text Domain: force-update-translations
@@ -46,7 +46,8 @@ class Force_Update_Translations {
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
-			$locale = get_user_locale();
+			$locale  = get_user_locale();
+			$sources = array();
 
 			foreach ( array( 'po', 'mo' ) as $format ) {
 				$file = $this->get_file( $project, $locale, $format );
@@ -55,6 +56,8 @@ class Force_Update_Translations {
 						'status'  => 'error',
 						'content' => $file->get_error_message(),
 					);
+				} elseif ( is_string( $file ) && '' !== $file ) {
+					$sources[] = $file;
 				}
 			}
 
@@ -68,11 +71,7 @@ class Force_Update_Translations {
 				} else {
 					$this->admin_notices[ $key ][] = array(
 						'status'  => 'success',
-						'content' => sprintf(
-							/* translators: %s: Translation file. */
-							__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
-							'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
-						),
+						'content' => $this->get_download_success_message( $project, $sources ),
 					);
 				}
 			}
@@ -95,7 +94,7 @@ class Force_Update_Translations {
 	 * @param string $locale  File locale.
 	 * @param string $format  File format.
 	 *
-	 * @return null|WP_Error File path to get source.
+	 * @return string|WP_Error Project branch used (`dev`, `stable`, or empty string for themes) on success.
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
@@ -108,12 +107,17 @@ class Force_Update_Translations {
 
 		switch ( $project['type'] ) {
 			case 'plugin':
-				$target_path   = 'plugins/' . $project['sub_project']['slug'];
-				// Development first (includes newest / waiting strings), then Stable.
-				$project_paths = array(
-					'wp-' . $target_path . '/dev',
-					'wp-' . $target_path . '/stable',
-				);
+				$target_path = 'plugins/' . $project['sub_project']['slug'];
+				$branch      = isset( $project['branch'] ) ? $project['branch'] : '';
+				if ( 'stable' === $branch || 'dev' === $branch ) {
+					$project_paths = array( 'wp-' . $target_path . '/' . $branch );
+				} else {
+					// Development first (includes newest / waiting strings), then Stable.
+					$project_paths = array(
+						'wp-' . $target_path . '/dev',
+						'wp-' . $target_path . '/stable',
+					);
+				}
 				break;
 			case 'theme':
 				$target_path   = 'themes/' . $project['sub_project']['slug'];
@@ -156,7 +160,7 @@ class Force_Update_Translations {
 			}
 
 			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
-			return null;
+			return $this->get_project_branch( $project_path );
 		}
 
 		return new WP_Error(
@@ -166,6 +170,117 @@ class Force_Update_Translations {
 				__( 'Cannot get source file: %s', 'force-update-translations' ),
 				'<b>' . esc_html( $last_source ) . '</b>'
 			)
+		);
+	}
+
+	/**
+	 * Extract Stable/Development branch from a translate.wordpress.org project path.
+	 *
+	 * @param string $project_path Project path such as wp-plugins/slug/dev.
+	 * @return string `dev`, `stable`, or empty string when not applicable.
+	 */
+	protected function get_project_branch( $project_path ) {
+		if ( preg_match( '#/(dev|stable)$#', $project_path, $matches ) ) {
+			return $matches[1];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect Stable/Development branch from a local PO file header.
+	 *
+	 * @param string $po_path Path to PO file.
+	 * @return string `dev`, `stable`, or empty string when unknown.
+	 */
+	public function detect_branch_from_po( $po_path ) {
+		if ( ! is_readable( $po_path ) ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$headers = file_get_contents( $po_path, false, null, 0, 4096 );
+		if ( false === $headers ) {
+			return '';
+		}
+
+		if ( preg_match( '/Project-Id-Version:.*\bDevelopment\b/i', $headers ) ) {
+			return 'dev';
+		}
+
+		if ( preg_match( '/Project-Id-Version:.*\bStable\b/i', $headers ) ) {
+			return 'stable';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect branch for an installed plugin or theme translation.
+	 *
+	 * @param string $type `plugin` or `theme`.
+	 * @param string $slug Text domain / slug.
+	 * @param string $locale Locale. Defaults to the current user locale.
+	 * @return string `dev`, `stable`, or empty string when unknown.
+	 */
+	public function detect_installed_branch( $type, $slug, $locale = '' ) {
+		if ( empty( $locale ) ) {
+			$locale = get_user_locale();
+		}
+
+		$subdir = ( 'theme' === $type ) ? 'themes' : 'plugins';
+		$po     = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale . '.po';
+
+		return $this->detect_branch_from_po( $po );
+	}
+
+	/**
+	 * Human-readable label for a GlotPress project branch.
+	 *
+	 * @param string $branch Branch slug (`dev` or `stable`).
+	 * @return string
+	 */
+	protected function get_branch_label( $branch ) {
+		switch ( $branch ) {
+			case 'dev':
+				return __( 'Development', 'force-update-translations' );
+			case 'stable':
+				return __( 'Stable', 'force-update-translations' );
+			default:
+				return $branch;
+		}
+	}
+
+	/**
+	 * Build the success notice after translation files are downloaded.
+	 *
+	 * @param array    $project Project data.
+	 * @param string[] $sources Branch slugs used for downloads.
+	 * @return string
+	 */
+	protected function get_download_success_message( $project, $sources ) {
+		$name    = '<b>' . esc_html( $project['sub_project']['name'] ) . '</b>';
+		$sources = array_values( array_unique( array_filter( $sources ) ) );
+
+		if ( empty( $sources ) ) {
+			return sprintf(
+				/* translators: %s: Theme or plugin name. */
+				__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
+				$name
+			);
+		}
+
+		$labels = array();
+		foreach ( $sources as $source ) {
+			$labels[] = $this->get_branch_label( $source );
+		}
+		$branch_label = '<b>' . esc_html( implode( ', ', $labels ) ) . '</b>';
+
+		return sprintf(
+			/* translators: 1: Theme or plugin name. 2: Translation project branch (Development or Stable). */
+			__( 'Translation files have been downloaded: %1$s (source: %2$s)', 'force-update-translations' ),
+			$name,
+			$branch_label
 		);
 	}
 
@@ -385,7 +500,7 @@ class Force_Update_Translations {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 		$data = get_plugin_data( __FILE__, false, false );
-		return isset( $data['Version'] ) ? $data['Version'] : '0.6.2';
+		return isset( $data['Version'] ) ? $data['Version'] : '0.6.3';
 	}
 
 	/**

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -26,19 +26,6 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 	 * @return array Modified array of plugin action links.
 	 */
 	public function plugin_action_links( $actions, $plugin_file ) {
-		$url         = wp_nonce_url(
-			admin_url( 'plugins.php?force_translate=' . $plugin_file ),
-			'force_translate_plugin_' . $plugin_file,
-			'force_translate_nonce'
-		);
-		$new_actions = array(
-			'force_translate' => sprintf(
-				'<a href="%1$s">%2$s</a>',
-				esc_url( $url ),
-				esc_html__( 'Update translation', 'force-update-translations' )
-			),
-		);
-
 		// Check if plugin is on wordpress.org by checking if ID (from Plugin wp.org info) exists in 'response' or 'no_update'.
 		$on_wporg     = false;
 		$plugin_state = get_site_transient( 'update_plugins' );
@@ -47,9 +34,51 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		}
 
 		// Add action if plugin is on wordpress.org and if user Locale isn't 'en_US'.
-		if ( ( $on_wporg ) && ( get_user_locale() !== 'en_US' ) ) {
-			$actions = array_merge( $actions, $new_actions );
+		if ( ! $on_wporg || get_user_locale() === 'en_US' ) {
+			return $actions;
 		}
+
+		$installed_branch = '';
+		if ( preg_match( '/^([a-zA-Z0-9-_]+)\//', $plugin_file, $plugin_slug ) ) {
+			$installed_branch = $this->detect_installed_branch( 'plugin', $plugin_slug[1] );
+		}
+
+		$branch_links = array();
+		foreach ( array( 'stable', 'dev' ) as $branch ) {
+			$url   = wp_nonce_url(
+				admin_url(
+					add_query_arg(
+						array(
+							'force_translate'        => $plugin_file,
+							'force_translate_branch' => $branch,
+						),
+						'plugins.php'
+					)
+				),
+				'force_translate_plugin_' . $plugin_file . '_' . $branch,
+				'force_translate_nonce'
+			);
+			$label = $this->get_branch_label( $branch );
+			if ( $branch === $installed_branch ) {
+				$label = sprintf(
+					/* translators: %s: Translation project branch (Development or Stable). */
+					__( '%s (current)', 'force-update-translations' ),
+					$label
+				);
+			}
+			$branch_links[] = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $url ),
+				esc_html( $label )
+			);
+		}
+
+		$actions['force_translate'] = sprintf(
+			'%1$s: %2$s',
+			esc_html__( 'Update translation', 'force-update-translations' ),
+			implode( ' | ', $branch_links )
+		);
+
 		return $actions;
 	}
 
@@ -65,10 +94,20 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		}
 
 		$plugin_file = sanitize_text_field( wp_unslash( $_GET['force_translate'] ) );
+		$branch      = isset( $_GET['force_translate_branch'] ) ? sanitize_key( wp_unslash( $_GET['force_translate_branch'] ) ) : '';
+
+		if ( ! in_array( $branch, array( 'stable', 'dev' ), true ) ) {
+			$this->admin_notices['error'][] = array(
+				'status'  => 'error',
+				'content' => esc_html__( 'Please choose Stable or Development as the translation source.', 'force-update-translations' ),
+			);
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+			return;
+		}
 
 		// Verify nonce for CSRF protection.
 		if ( ! isset( $_GET['force_translate_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['force_translate_nonce'] ) ), 'force_translate_plugin_' . $plugin_file ) ) {
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['force_translate_nonce'] ) ), 'force_translate_plugin_' . $plugin_file . '_' . $branch ) ) {
 			$this->admin_notices['error'][] = array(
 				'status'  => 'error',
 				'content' => esc_html__( 'Security verification failed. Please refresh the page and try again.', 'force-update-translations' ),
@@ -122,6 +161,7 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		$projects = array(
 			$plugin_file => array(
 				'type'        => 'plugin',
+				'branch'      => $branch,
 				'sub_project' => array(
 					'slug' => $plugin_slug[1],
 					'name' => $plugin_data['Name'],

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -119,11 +119,13 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false );
 
-		$projects[ $plugin_file ] = array(
-			'type'        => 'plugin',
-			'sub_project' => array(
-				'slug' => $plugin_slug[1],
-				'name' => $plugin_data['Name'],
+		$projects = array(
+			$plugin_file => array(
+				'type'        => 'plugin',
+				'sub_project' => array(
+					'slug' => $plugin_slug[1],
+					'name' => $plugin_data['Name'],
+				),
 			),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 5.6
-Stable tag: 0.6.2
+Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 5.6
-Stable tag: 0.6.1
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- プラグイン翻訳の取得元として Stable / Development を選択できるようにしました
- インストール済み翻訳が Stable / Development のどちら由来かをプラグイン一覧と成功通知に表示します
- ダウンロードした PO/MO から Jed JSON と `.l10n.php` を生成し、未承認翻訳も JS / PHP で反映しやすくしました（0.6.2）

## Test plan
- [ ] ロケールが `en_US` 以外のユーザーで、WordPress.org 上のプラグインに「Update translation: Stable | Development」が表示される
- [ ] Stable / Development それぞれを実行し、成功通知に `source: Stable` / `source: Development` が出る
- [ ] 取得後、同じリンク横に `(current)` が付く
- [ ] 存在しないソースを指定した場合にフォールバックせずエラーになる
- [ ] 取得後に `WP_LANG_DIR/plugins/` 配下へ `.po` / `.mo` / `.json` / `.l10n.php` が生成される
- [ ] テーマの翻訳更新が従来どおり動作する


Made with [Cursor](https://cursor.com)