### PR TITLE
タグ push 時に plugin-zip で GitHub Release を作成する

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,12 @@
 /.wordpress-org
 /.git
 /.github
+/node_modules
 .distignore
 .gitignore
 README.md
+deno.json
+deno.lock
+package.json
+package-lock.json
+*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release plugin zip
+on:
+  push:
+    tags:
+      - "*"
+permissions:
+  contents: write
+jobs:
+  zip:
+    name: Build and attach zip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: deno install
+
+      - name: Build plugin zip
+        run: deno task plugin-zip
+
+      - name: Verify zip
+        run: test -f force-update-translations.zip && ls -la force-update-translations.zip
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" force-update-translations.zip --clobber
+          else
+            gh release create "$TAG" force-update-translations.zip --generate-notes --title "$TAG"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.zip
+node_modules/
+deno.lock
+package-lock.json

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,15 @@
+{
+	"tasks": {
+		"check": "deno fmt --check deno.json package.json",
+		"build": "deno task plugin-zip",
+		"plugin-zip": "deno x wp-scripts plugin-zip && zip -d force-update-translations.zip force-update-translations/package.json force-update-translations/README.md"
+	},
+	"nodeModulesDir": "auto",
+	"fmt": {
+		"indentWidth": 4,
+		"useTabs": true,
+		"lineWidth": 400,
+		"include": ["deno.json", "package.json"],
+		"exclude": ["node_modules", ".github"]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "force-update-translations",
+	"version": "0.6.3",
+	"description": "Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.",
+	"author": "Mayo Moriyama & Contributors",
+	"license": "GPL-2.0-or-later",
+	"scripts": {
+		"plugin-zip": "wp-scripts plugin-zip"
+	},
+	"files": [
+		"force-update-translations.php",
+		"readme.txt",
+		"inc",
+		"lib"
+	],
+	"devDependencies": {
+		"@wordpress/scripts": "^30"
+	}
+}


### PR DESCRIPTION
## Summary
- タグ push 時に `@wordpress/scripts` の `plugin-zip` で配布用 zip を作成し、GitHub Release に添付する workflow を追加しました
- ローカルでも `deno task plugin-zip` で同じ zip を作成できます
- WordPress.org 向け `.distignore` に Deno / npm 関連ファイルを追加しました

## Test plan
- [ ] `deno task plugin-zip` で `force-update-translations.zip` が生成される
- [ ] zip 内に `force-update-translations.php` / `inc` / `lib` / `readme.txt` が含まれ、`package.json` / `README.md` / `.github` は含まれない
- [ ] タグを push すると `Release plugin zip` workflow が成功し、GitHub Release に zip が添付される
- [ ] 既存の WordPress.org deploy workflow に影響しない


Made with [Cursor](https://cursor.com)