### PR TITLE
設定画面でロケール選択・言語パック上書き保護・一括更新を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ To download the translation files for a plugin:
 
 ## Changelog
 
+= 0.6.3 - 2026-07-28 =
+* Feature: Choose Stable or Development as the translation source when updating plugin translations
+* Feature: Show whether installed plugin translations came from Stable or Development
+
 = 0.6.0 - 2025-12-17 =
 * Security: Fixed CSRF vulnerability (CVE-2025-58236)
 * Security: Added nonce verification and permission checks for translation updates

--- a/README.md
+++ b/README.md
@@ -4,27 +4,36 @@
 
 Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
 
-> **Warning**: Currently this plugin downloads only strings from Development project instead of Stable for plugins. Please wait for an update or see <a href="https://github.com/mayukojpn/force-update-translations/issues/37">the issue on GitHub</a>.
-
-> **Warning**: Currently this plugin is not able to generate the JSON files that is needed for JavaScript to consume some translations. Please wait for update or see <a href="https://github.com/mayukojpn/force-update-translations/issues/24">the issue on GitHub</a>.
+This plugin exports Current + Waiting (suggestions) + Fuzzy strings from translate.wordpress.org, writes them into `WP_LANG_DIR`, and generates Jed JSON / `.l10n.php` so PHP and JavaScript strings can both apply.
 
 ## Usage
 
-### Theme translation
-
-Finally, updating theme translation files is now supported! To download the translation files for a theme:
-
-1. Activate the theme you want to get the translation files.
-1. Visit 'Appearance' > 'Update translation' in WordPress menu, or click 'Update translation' on theme details of current theme on 'Themes' page.
-
 ### Plugin translation
 
-To download the translation files for a plugin:
+1. Visit **Plugins**.
+1. Under a WordPress.org plugin, choose **Update translation: Stable** or **Development**.
+1. The link marked `(current)` shows which source is installed locally.
 
-1. Visit 'Plugins' in WordPress menu.
-1. Click 'Update translation' under the name of the plugin for which you want to get the translation files.
+### Theme translation
+
+1. Activate the theme you want to update.
+1. Visit **Appearance → Update translation**.
+1. Click **Update translation**.
+
+### Settings
+
+Visit **Settings → Force Update Translations** to:
+
+- Choose whether downloads use the **user language** or the **site language**
+- Enable/disable protection against official language-pack overwrites
+- Bulk-update translations for installed WordPress.org plugins
 
 ## Changelog
+
+= 0.6.4 - 2026-07-28 =
+* Feature: Settings screen for locale source (user vs site language)
+* Feature: Protect forced translations from being overwritten by official language packs
+* Feature: Bulk update for installed WordPress.org plugins
 
 = 0.6.3 - 2026-07-28 =
 * Feature: Choose Stable or Development as the translation source when updating plugin translations

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -4,7 +4,7 @@
  * Description: Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
  * Author:      Mayo Moriyama & Contributors
  * Author URI:  https://github.com/mayukojpn/force-update-translations/graphs/contributors
- * Version:     0.6.1
+ * Version:     0.6.2
  * Requires at least: 4.7
  * Requires PHP: 5.6
  * Text Domain: force-update-translations
@@ -23,7 +23,7 @@ class Force_Update_Translations {
 	/**
 	 * Admin notices array.
 	 *
-	 * @var array<string, array<int, array<string, string>>>
+	 * @var array
 	 */
 	public $admin_notices = array();
 
@@ -32,54 +32,70 @@ class Force_Update_Translations {
 	 */
 	public function __construct() {
 
-		include 'lib/glotpress/locales.php';
-		include 'inc/plugins.php';
-		include 'inc/themes.php';
+		include_once __DIR__ . '/lib/glotpress/locales.php';
+		include_once __DIR__ . '/inc/plugins.php';
+		include_once __DIR__ . '/inc/themes.php';
 	}
 
 	/**
 	 * Get translation files.
 	 *
-	 * @param array $projects     Array of translation projects.
+	 * @param array $projects Array of translation projects.
 	 *
 	 * @return void
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
+			$locale = get_user_locale();
+
 			foreach ( array( 'po', 'mo' ) as $format ) {
-				$file = $this->get_file( $project, get_user_locale(), $format );
+				$file = $this->get_file( $project, $locale, $format );
 				if ( is_wp_error( $file ) ) {
 					$this->admin_notices[ $key ][] = array(
 						'status'  => 'error',
 						'content' => $file->get_error_message(),
 					);
 				}
-			} // endforeach;
+			}
 
 			if ( empty( $this->admin_notices[ $key ] ) ) {
-				$this->admin_notices[ $key ][] = array(
-					'status'  => 'success',
-					'content' => sprintf(
-						/* translators: %s: Translation file. */
-						__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
-						'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
-					),
-				);
+				$derived = $this->generate_derived_translation_files( $project, $locale );
+				if ( is_wp_error( $derived ) ) {
+					$this->admin_notices[ $key ][] = array(
+						'status'  => 'error',
+						'content' => $derived->get_error_message(),
+					);
+				} else {
+					$this->admin_notices[ $key ][] = array(
+						'status'  => 'success',
+						'content' => sprintf(
+							/* translators: %s: Translation file. */
+							__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
+							'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
+						),
+					);
+				}
 			}
 		}
 
-		// Show admin notices of the projects translation update.
-		self::admin_notices();
+		// Defer notices until admin_notices when that hook has not yet run
+		// (e.g. plugin updates during admin_init). Print immediately when the
+		// hook already fired (e.g. theme translation settings page callback).
+		if ( ! did_action( 'admin_notices' ) ) {
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+		} else {
+			$this->admin_notices();
+		}
 	}
 
 	/**
 	 * Get translation source file.
 	 *
-	 * @param array  $project   File project.
-	 * @param string $locale    File locale.
-	 * @param string $format    File format.
+	 * @param array  $project File project.
+	 * @param string $locale  File locale.
+	 * @param string $format  File format.
 	 *
-	 * @return null|WP_Error    File path to get source..
+	 * @return null|WP_Error File path to get source.
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
@@ -87,18 +103,24 @@ class Force_Update_Translations {
 			$locale = get_user_locale();
 		}
 
+		$target_path   = '';
+		$project_paths = array();
+
 		switch ( $project['type'] ) {
 			case 'plugin':
-				$target_path  = 'plugins/' . $project['sub_project']['slug'];
-				$project_path = 'wp-' . $target_path . '/dev';
+				$target_path   = 'plugins/' . $project['sub_project']['slug'];
+				// Development first (includes newest / waiting strings), then Stable.
+				$project_paths = array(
+					'wp-' . $target_path . '/dev',
+					'wp-' . $target_path . '/stable',
+				);
 				break;
 			case 'theme':
-				$target_path  = 'themes/' . $project['sub_project']['slug'];
-				$project_path = 'wp-' . $target_path;
+				$target_path   = 'themes/' . $project['sub_project']['slug'];
+				$project_paths = array( 'wp-' . $target_path );
 				break;
 		}
 
-		$source = $this->get_source_path( $project_path, $locale, $format );
 		$target = sprintf(
 			'%s-%s.%s',
 			$target_path,
@@ -106,37 +128,54 @@ class Force_Update_Translations {
 			$format
 		);
 
-		$response = wp_remote_get( $source );
-
-		if ( ! is_array( $response )
-			|| 'application/octet-stream' !== $response['headers']['content-type'] ) {
-			return new WP_Error(
-				'fdt-source-not-found',
-				sprintf(
-					/* translators: %s: Translation file. */
-					__( 'Cannot get source file: %s', 'force-update-translations' ),
-					'<b>' . esc_html( $source ) . '</b>'
+		$last_source = '';
+		foreach ( $project_paths as $project_path ) {
+			$source      = $this->get_source_path( $project_path, $locale, $format );
+			$last_source = $source;
+			$response    = wp_remote_get(
+				$source,
+				array(
+					'timeout' => 60,
 				)
 			);
-		} else {
+
+			$content_type = '';
+			if ( is_array( $response ) && isset( $response['headers']['content-type'] ) ) {
+				$content_type = $response['headers']['content-type'];
+			}
+
+			if ( ! is_array( $response )
+				|| false === strpos( $content_type, 'application/octet-stream' ) ) {
+				continue;
+			}
+
 			$translation_path = WP_LANG_DIR . '/' . $target;
 
 			if ( ! file_exists( pathinfo( $translation_path, PATHINFO_DIRNAME ) ) ) {
 				mkdir( pathinfo( $translation_path, PATHINFO_DIRNAME ), 0777, true );
 			}
 
-            file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
-			return;
+			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
+			return null;
 		}
+
+		return new WP_Error(
+			'fdt-source-not-found',
+			sprintf(
+				/* translators: %s: Translation file. */
+				__( 'Cannot get source file: %s', 'force-update-translations' ),
+				'<b>' . esc_html( $last_source ) . '</b>'
+			)
+		);
 	}
 
 	/**
 	 * Generate a file path to get translation file.
 	 *
-	 * @param string $project   File project.
-	 * @param string $locale    File locale.
-	 * @param string $format    File format.
-	 * @return $path            File path to get source.
+	 * @param string $project File project.
+	 * @param string $locale  File locale.
+	 * @param string $format  File format.
+	 * @return string File path to get source.
 	 */
 	public function get_source_path( $project, $locale, $format = 'mo' ) {
 		$locale = GP_Locales::by_field( 'wp_locale', $locale );
@@ -155,6 +194,198 @@ class Force_Update_Translations {
 		$path = ( 'po' === $format ) ? $path : $path . '&format=' . $format;
 		$path = esc_url_raw( $path );
 		return $path;
+	}
+
+	/**
+	 * Build .json (JS) and .l10n.php files from the downloaded PO/MO.
+	 *
+	 * Modern WordPress loads JS strings from Jed JSON files and prefers
+	 * .l10n.php over .mo for PHP strings. Without these, unapproved
+	 * translations in the PO/MO often appear not to apply.
+	 *
+	 * @param array  $project Project data.
+	 * @param string $locale  Locale.
+	 * @return true|WP_Error
+	 */
+	public function generate_derived_translation_files( $project, $locale ) {
+		$subdir = ( 'theme' === $project['type'] ) ? 'themes' : 'plugins';
+		$slug   = $project['sub_project']['slug'];
+		$base   = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale;
+		$po     = $base . '.po';
+		$mo     = $base . '.mo';
+
+		if ( ! is_readable( $po ) ) {
+			return new WP_Error(
+				'fdt-po-missing',
+				sprintf(
+					/* translators: %s: File path. */
+					__( 'Cannot generate translation artifacts; PO file missing: %s', 'force-update-translations' ),
+					'<b>' . esc_html( $po ) . '</b>'
+				)
+			);
+		}
+
+		$this->delete_existing_json_files( $subdir, $slug, $locale );
+
+		$json_result = $this->make_json_files( $po, dirname( $po ), $slug . '-' . $locale );
+		if ( is_wp_error( $json_result ) ) {
+			return $json_result;
+		}
+
+		if ( is_readable( $mo ) && class_exists( 'WP_Translation_File', false ) ) {
+			$php = WP_Translation_File::transform( $mo, 'php' );
+			if ( is_string( $php ) && '' !== $php ) {
+				file_put_contents( $base . '.l10n.php', $php ); // phpcs:ignore
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Remove previously generated Jed JSON files for a domain/locale.
+	 *
+	 * @param string $subdir plugins or themes.
+	 * @param string $slug   Text domain / slug.
+	 * @param string $locale Locale.
+	 * @return void
+	 */
+	protected function delete_existing_json_files( $subdir, $slug, $locale ) {
+		$pattern = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale . '-*.json';
+		$files   = glob( $pattern );
+		if ( empty( $files ) ) {
+			return;
+		}
+		foreach ( $files as $file ) {
+			unlink( $file ); // phpcs:ignore
+		}
+	}
+
+	/**
+	 * Split a PO file into Jed JSON files (one per JS source file).
+	 *
+	 * @param string $po_file         Path to PO file.
+	 * @param string $destination_dir Destination directory.
+	 * @param string $base_file_name  Filename prefix (domain-locale).
+	 * @return int|WP_Error Number of JSON files created.
+	 */
+	protected function make_json_files( $po_file, $destination_dir, $base_file_name ) {
+		if ( ! class_exists( 'PO', false ) ) {
+			require_once ABSPATH . WPINC . '/pomo/po.php';
+		}
+
+		$po = new PO();
+		if ( ! $po->import_from_file( $po_file ) ) {
+			return new WP_Error(
+				'fdt-po-parse',
+				sprintf(
+					/* translators: %s: File path. */
+					__( 'Could not parse PO file: %s', 'force-update-translations' ),
+					'<b>' . esc_html( $po_file ) . '</b>'
+				)
+			);
+		}
+
+		$js_extensions = array( 'js', 'jsx', 'ts', 'tsx' );
+		$mapping       = array();
+
+		foreach ( $po->entries as $entry ) {
+			if ( empty( $entry->translations ) || '' === $entry->translations[0] ) {
+				continue;
+			}
+
+			$sources = array();
+			foreach ( (array) $entry->references as $reference ) {
+				$file = $reference;
+				if ( preg_match( '/^(.+):(\d+)$/', $reference, $matches ) ) {
+					$file = $matches[1];
+				}
+
+				$extension = pathinfo( $file, PATHINFO_EXTENSION );
+				if ( ! in_array( $extension, $js_extensions, true ) ) {
+					continue;
+				}
+
+				// Normalize foo.min.js -> foo.js (matches wp i18n make-json).
+				$file      = preg_replace( '/\.min\.' . preg_quote( $extension, '/' ) . '$/', '.' . $extension, $file );
+				$sources[] = $file;
+			}
+
+			$sources = array_unique( $sources );
+			foreach ( $sources as $source ) {
+				if ( ! isset( $mapping[ $source ] ) ) {
+					$mapping[ $source ] = array();
+				}
+				$mapping[ $source ][] = $entry;
+			}
+		}
+
+		$created = 0;
+		foreach ( $mapping as $source => $entries ) {
+			$jed = $this->build_jed_json( $po, $entries, $source );
+			$file = $destination_dir . '/' . $base_file_name . '-' . md5( $source ) . '.json';
+			$json = wp_json_encode( $jed );
+			if ( false === $json ) {
+				continue;
+			}
+			file_put_contents( $file, $json ); // phpcs:ignore
+			++$created;
+		}
+
+		return $created;
+	}
+
+	/**
+	 * Build a Jed 1.x compatible data structure for script translations.
+	 *
+	 * @param PO                 $po      Parsed PO (for headers).
+	 * @param Translation_Entry[] $entries Entries for one JS source file.
+	 * @param string             $source  Relative JS source path.
+	 * @return array
+	 */
+	protected function build_jed_json( $po, $entries, $source ) {
+		$lang         = isset( $po->headers['Language'] ) ? $po->headers['Language'] : '';
+		$plural_forms = isset( $po->headers['Plural-Forms'] ) ? $po->headers['Plural-Forms'] : 'nplurals=2; plural=n != 1;';
+		$revision     = isset( $po->headers['PO-Revision-Date'] ) ? $po->headers['PO-Revision-Date'] : '';
+
+		$messages = array(
+			'' => array(
+				'domain'       => 'messages',
+				'lang'         => $lang,
+				'plural-forms' => $plural_forms,
+			),
+		);
+
+		foreach ( $entries as $entry ) {
+			$key = $entry->singular;
+			if ( ! empty( $entry->context ) ) {
+				$key = $entry->context . "\4" . $entry->singular;
+			}
+			$messages[ $key ] = array_values( $entry->translations );
+		}
+
+		return array(
+			'translation-revision-date' => $revision,
+			'generator'                 => 'Force Update Translations/' . $this->get_plugin_version(),
+			'source'                    => $source,
+			'domain'                    => 'messages',
+			'locale_data'               => array(
+				'messages' => $messages,
+			),
+		);
+	}
+
+	/**
+	 * Plugin version from the main file header.
+	 *
+	 * @return string
+	 */
+	protected function get_plugin_version() {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$data = get_plugin_data( __FILE__, false, false );
+		return isset( $data['Version'] ) ? $data['Version'] : '0.6.2';
 	}
 
 	/**

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -4,7 +4,7 @@
  * Description: Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
  * Author:      Mayo Moriyama & Contributors
  * Author URI:  https://github.com/mayukojpn/force-update-translations/graphs/contributors
- * Version:     0.6.2
+ * Version:     0.6.3
  * Requires at least: 4.7
  * Requires PHP: 5.6
  * Text Domain: force-update-translations
@@ -46,7 +46,8 @@ class Force_Update_Translations {
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
-			$locale = get_user_locale();
+			$locale  = get_user_locale();
+			$sources = array();
 
 			foreach ( array( 'po', 'mo' ) as $format ) {
 				$file = $this->get_file( $project, $locale, $format );
@@ -55,6 +56,8 @@ class Force_Update_Translations {
 						'status'  => 'error',
 						'content' => $file->get_error_message(),
 					);
+				} elseif ( is_string( $file ) && '' !== $file ) {
+					$sources[] = $file;
 				}
 			}
 
@@ -68,11 +71,7 @@ class Force_Update_Translations {
 				} else {
 					$this->admin_notices[ $key ][] = array(
 						'status'  => 'success',
-						'content' => sprintf(
-							/* translators: %s: Translation file. */
-							__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
-							'<b>' . esc_html( $project['sub_project']['name'] ) . '</b>'
-						),
+						'content' => $this->get_download_success_message( $project, $sources ),
 					);
 				}
 			}
@@ -95,7 +94,7 @@ class Force_Update_Translations {
 	 * @param string $locale  File locale.
 	 * @param string $format  File format.
 	 *
-	 * @return null|WP_Error File path to get source.
+	 * @return string|WP_Error Project branch used (`dev`, `stable`, or empty string for themes) on success.
 	 */
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
@@ -108,12 +107,17 @@ class Force_Update_Translations {
 
 		switch ( $project['type'] ) {
 			case 'plugin':
-				$target_path   = 'plugins/' . $project['sub_project']['slug'];
-				// Development first (includes newest / waiting strings), then Stable.
-				$project_paths = array(
-					'wp-' . $target_path . '/dev',
-					'wp-' . $target_path . '/stable',
-				);
+				$target_path = 'plugins/' . $project['sub_project']['slug'];
+				$branch      = isset( $project['branch'] ) ? $project['branch'] : '';
+				if ( 'stable' === $branch || 'dev' === $branch ) {
+					$project_paths = array( 'wp-' . $target_path . '/' . $branch );
+				} else {
+					// Development first (includes newest / waiting strings), then Stable.
+					$project_paths = array(
+						'wp-' . $target_path . '/dev',
+						'wp-' . $target_path . '/stable',
+					);
+				}
 				break;
 			case 'theme':
 				$target_path   = 'themes/' . $project['sub_project']['slug'];
@@ -156,7 +160,7 @@ class Force_Update_Translations {
 			}
 
 			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
-			return null;
+			return $this->get_project_branch( $project_path );
 		}
 
 		return new WP_Error(
@@ -166,6 +170,117 @@ class Force_Update_Translations {
 				__( 'Cannot get source file: %s', 'force-update-translations' ),
 				'<b>' . esc_html( $last_source ) . '</b>'
 			)
+		);
+	}
+
+	/**
+	 * Extract Stable/Development branch from a translate.wordpress.org project path.
+	 *
+	 * @param string $project_path Project path such as wp-plugins/slug/dev.
+	 * @return string `dev`, `stable`, or empty string when not applicable.
+	 */
+	protected function get_project_branch( $project_path ) {
+		if ( preg_match( '#/(dev|stable)$#', $project_path, $matches ) ) {
+			return $matches[1];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect Stable/Development branch from a local PO file header.
+	 *
+	 * @param string $po_path Path to PO file.
+	 * @return string `dev`, `stable`, or empty string when unknown.
+	 */
+	public function detect_branch_from_po( $po_path ) {
+		if ( ! is_readable( $po_path ) ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$headers = file_get_contents( $po_path, false, null, 0, 4096 );
+		if ( false === $headers ) {
+			return '';
+		}
+
+		if ( preg_match( '/Project-Id-Version:.*\bDevelopment\b/i', $headers ) ) {
+			return 'dev';
+		}
+
+		if ( preg_match( '/Project-Id-Version:.*\bStable\b/i', $headers ) ) {
+			return 'stable';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect branch for an installed plugin or theme translation.
+	 *
+	 * @param string $type `plugin` or `theme`.
+	 * @param string $slug Text domain / slug.
+	 * @param string $locale Locale. Defaults to the current user locale.
+	 * @return string `dev`, `stable`, or empty string when unknown.
+	 */
+	public function detect_installed_branch( $type, $slug, $locale = '' ) {
+		if ( empty( $locale ) ) {
+			$locale = get_user_locale();
+		}
+
+		$subdir = ( 'theme' === $type ) ? 'themes' : 'plugins';
+		$po     = WP_LANG_DIR . '/' . $subdir . '/' . $slug . '-' . $locale . '.po';
+
+		return $this->detect_branch_from_po( $po );
+	}
+
+	/**
+	 * Human-readable label for a GlotPress project branch.
+	 *
+	 * @param string $branch Branch slug (`dev` or `stable`).
+	 * @return string
+	 */
+	protected function get_branch_label( $branch ) {
+		switch ( $branch ) {
+			case 'dev':
+				return __( 'Development', 'force-update-translations' );
+			case 'stable':
+				return __( 'Stable', 'force-update-translations' );
+			default:
+				return $branch;
+		}
+	}
+
+	/**
+	 * Build the success notice after translation files are downloaded.
+	 *
+	 * @param array    $project Project data.
+	 * @param string[] $sources Branch slugs used for downloads.
+	 * @return string
+	 */
+	protected function get_download_success_message( $project, $sources ) {
+		$name    = '<b>' . esc_html( $project['sub_project']['name'] ) . '</b>';
+		$sources = array_values( array_unique( array_filter( $sources ) ) );
+
+		if ( empty( $sources ) ) {
+			return sprintf(
+				/* translators: %s: Theme or plugin name. */
+				__( 'Translation files have been downloaded: %s', 'force-update-translations' ),
+				$name
+			);
+		}
+
+		$labels = array();
+		foreach ( $sources as $source ) {
+			$labels[] = $this->get_branch_label( $source );
+		}
+		$branch_label = '<b>' . esc_html( implode( ', ', $labels ) ) . '</b>';
+
+		return sprintf(
+			/* translators: 1: Theme or plugin name. 2: Translation project branch (Development or Stable). */
+			__( 'Translation files have been downloaded: %1$s (source: %2$s)', 'force-update-translations' ),
+			$name,
+			$branch_label
 		);
 	}
 
@@ -385,7 +500,7 @@ class Force_Update_Translations {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 		$data = get_plugin_data( __FILE__, false, false );
-		return isset( $data['Version'] ) ? $data['Version'] : '0.6.2';
+		return isset( $data['Version'] ) ? $data['Version'] : '0.6.3';
 	}
 
 	/**

--- a/force-update-translations.php
+++ b/force-update-translations.php
@@ -4,7 +4,7 @@
  * Description: Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
  * Author:      Mayo Moriyama & Contributors
  * Author URI:  https://github.com/mayukojpn/force-update-translations/graphs/contributors
- * Version:     0.6.3
+ * Version:     0.6.4
  * Requires at least: 4.7
  * Requires PHP: 5.6
  * Text Domain: force-update-translations
@@ -21,6 +21,20 @@
 class Force_Update_Translations {
 
 	/**
+	 * Option name for plugin settings.
+	 *
+	 * @var string
+	 */
+	const SETTINGS_OPTION = 'fut_settings';
+
+	/**
+	 * Option name for tracked forced translations.
+	 *
+	 * @var string
+	 */
+	const FORCED_OPTION = 'fut_forced_translations';
+
+	/**
 	 * Admin notices array.
 	 *
 	 * @var array
@@ -35,6 +49,215 @@ class Force_Update_Translations {
 		include_once __DIR__ . '/lib/glotpress/locales.php';
 		include_once __DIR__ . '/inc/plugins.php';
 		include_once __DIR__ . '/inc/themes.php';
+		include_once __DIR__ . '/inc/settings.php';
+
+		add_filter( 'site_transient_update_plugins', array( $this, 'filter_translation_updates' ) );
+		add_filter( 'site_transient_update_themes', array( $this, 'filter_translation_updates' ) );
+		add_filter( 'site_transient_update_core', array( $this, 'filter_translation_updates' ) );
+		add_filter( 'auto_update_translation', array( $this, 'filter_auto_update_translation' ), 10, 2 );
+	}
+
+	/**
+	 * Default settings.
+	 *
+	 * @return array
+	 */
+	public static function default_settings() {
+		return array(
+			'locale_source'      => 'user',
+			'protect_from_packs' => 1,
+		);
+	}
+
+	/**
+	 * Get plugin settings merged with defaults.
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+		$settings = get_option( self::SETTINGS_OPTION, array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		return array_merge( self::default_settings(), $settings );
+	}
+
+	/**
+	 * Locale used for downloads and installed-branch detection.
+	 *
+	 * @return string
+	 */
+	public function get_target_locale() {
+		$settings = $this->get_settings();
+		if ( isset( $settings['locale_source'] ) && 'site' === $settings['locale_source'] ) {
+			return get_locale();
+		}
+		return get_user_locale();
+	}
+
+	/**
+	 * Whether official language-pack updates should skip forced translations.
+	 *
+	 * @return bool
+	 */
+	public function should_protect_from_packs() {
+		$settings = $this->get_settings();
+		return ! empty( $settings['protect_from_packs'] );
+	}
+
+	/**
+	 * Build storage key for a forced translation.
+	 *
+	 * @param string $type   plugin|theme.
+	 * @param string $slug   Project slug.
+	 * @param string $locale Locale.
+	 * @return string
+	 */
+	public function get_forced_key( $type, $slug, $locale ) {
+		return $type . '/' . $slug . '/' . $locale;
+	}
+
+	/**
+	 * Remember a successfully forced translation so language packs do not overwrite it.
+	 *
+	 * @param array  $project Project data.
+	 * @param string $locale  Locale.
+	 * @param string $branch  Branch slug when known.
+	 * @return void
+	 */
+	public function remember_forced_translation( $project, $locale, $branch = '' ) {
+		$type = isset( $project['type'] ) ? $project['type'] : '';
+		$slug = isset( $project['sub_project']['slug'] ) ? $project['sub_project']['slug'] : '';
+		if ( '' === $type || '' === $slug || '' === $locale ) {
+			return;
+		}
+
+		$key    = $this->get_forced_key( $type, $slug, $locale );
+		$forced = get_option( self::FORCED_OPTION, array() );
+		if ( ! is_array( $forced ) ) {
+			$forced = array();
+		}
+
+		$forced[ $key ] = array(
+			'type'      => $type,
+			'slug'      => $slug,
+			'locale'    => $locale,
+			'branch'    => $branch,
+			'updated'   => time(),
+			'protected' => 1,
+		);
+
+		update_option( self::FORCED_OPTION, $forced, false );
+	}
+
+	/**
+	 * Get all tracked forced translations.
+	 *
+	 * @return array
+	 */
+	public function get_forced_translations() {
+		$forced = get_option( self::FORCED_OPTION, array() );
+		return is_array( $forced ) ? $forced : array();
+	}
+
+	/**
+	 * Remove forced-translation tracking entries.
+	 *
+	 * @param string $type Optional type filter.
+	 * @param string $slug Optional slug filter.
+	 * @return int Number of removed entries.
+	 */
+	public function clear_forced_translations( $type = '', $slug = '' ) {
+		$forced = $this->get_forced_translations();
+		$before = count( $forced );
+
+		if ( '' === $type && '' === $slug ) {
+			delete_option( self::FORCED_OPTION );
+			return $before;
+		}
+
+		foreach ( $forced as $key => $entry ) {
+			if ( '' !== $type && ( ! isset( $entry['type'] ) || $entry['type'] !== $type ) ) {
+				continue;
+			}
+			if ( '' !== $slug && ( ! isset( $entry['slug'] ) || $entry['slug'] !== $slug ) ) {
+				continue;
+			}
+			unset( $forced[ $key ] );
+		}
+
+		update_option( self::FORCED_OPTION, $forced, false );
+		return $before - count( $forced );
+	}
+
+	/**
+	 * Strip protected domains from language-pack update payloads.
+	 *
+	 * @param object|mixed $value Transient value.
+	 * @return object|mixed
+	 */
+	public function filter_translation_updates( $value ) {
+		if ( ! $this->should_protect_from_packs() || ! is_object( $value ) || empty( $value->translations ) || ! is_array( $value->translations ) ) {
+			return $value;
+		}
+
+		$forced = $this->get_forced_translations();
+		if ( empty( $forced ) ) {
+			return $value;
+		}
+
+		$value->translations = array_values(
+			array_filter(
+				$value->translations,
+				array( $this, 'is_translation_update_allowed' )
+			)
+		);
+
+		return $value;
+	}
+
+	/**
+	 * Whether a language-pack update entry may proceed.
+	 *
+	 * @param array $update Translation update row.
+	 * @return bool
+	 */
+	public function is_translation_update_allowed( $update ) {
+		if ( ! is_array( $update ) || empty( $update['type'] ) || empty( $update['slug'] ) || empty( $update['language'] ) ) {
+			return true;
+		}
+
+		$key    = $this->get_forced_key( $update['type'], $update['slug'], $update['language'] );
+		$forced = $this->get_forced_translations();
+		return empty( $forced[ $key ] );
+	}
+
+	/**
+	 * Block automatic language-pack updates for forced translations.
+	 *
+	 * @param bool|null $update Whether to update.
+	 * @param object    $item   Translation update item.
+	 * @return bool|null
+	 */
+	public function filter_auto_update_translation( $update, $item ) {
+		if ( ! $this->should_protect_from_packs() || ! is_object( $item ) ) {
+			return $update;
+		}
+
+		$type     = isset( $item->type ) ? $item->type : '';
+		$slug     = isset( $item->slug ) ? $item->slug : '';
+		$language = isset( $item->language ) ? $item->language : '';
+		if ( '' === $type || '' === $slug || '' === $language ) {
+			return $update;
+		}
+
+		$key    = $this->get_forced_key( $type, $slug, $language );
+		$forced = $this->get_forced_translations();
+		if ( ! empty( $forced[ $key ] ) ) {
+			return false;
+		}
+
+		return $update;
 	}
 
 	/**
@@ -46,7 +269,7 @@ class Force_Update_Translations {
 	 */
 	public function get_files( $projects ) {
 		foreach ( $projects as $key => $project ) {
-			$locale  = get_user_locale();
+			$locale  = $this->get_target_locale();
 			$sources = array();
 
 			foreach ( array( 'po', 'mo' ) as $format ) {
@@ -69,6 +292,8 @@ class Force_Update_Translations {
 						'content' => $derived->get_error_message(),
 					);
 				} else {
+					$branch = ! empty( $sources ) ? $sources[0] : ( isset( $project['branch'] ) ? $project['branch'] : '' );
+					$this->remember_forced_translation( $project, $locale, $branch );
 					$this->admin_notices[ $key ][] = array(
 						'status'  => 'success',
 						'content' => $this->get_download_success_message( $project, $sources ),
@@ -99,7 +324,7 @@ class Force_Update_Translations {
 	public function get_file( $project, $locale = '', $format = 'mo' ) {
 
 		if ( empty( $locale ) ) {
-			$locale = get_user_locale();
+			$locale = $this->get_target_locale();
 		}
 
 		$target_path   = '';
@@ -156,7 +381,7 @@ class Force_Update_Translations {
 			$translation_path = WP_LANG_DIR . '/' . $target;
 
 			if ( ! file_exists( pathinfo( $translation_path, PATHINFO_DIRNAME ) ) ) {
-				mkdir( pathinfo( $translation_path, PATHINFO_DIRNAME ), 0777, true );
+				wp_mkdir_p( pathinfo( $translation_path, PATHINFO_DIRNAME ) );
 			}
 
 			file_put_contents( $translation_path, $response['body'] ); // phpcs:ignore
@@ -225,7 +450,7 @@ class Force_Update_Translations {
 	 */
 	public function detect_installed_branch( $type, $slug, $locale = '' ) {
 		if ( empty( $locale ) ) {
-			$locale = get_user_locale();
+			$locale = $this->get_target_locale();
 		}
 
 		$subdir = ( 'theme' === $type ) ? 'themes' : 'plugins';
@@ -437,7 +662,7 @@ class Force_Update_Translations {
 
 		$created = 0;
 		foreach ( $mapping as $source => $entries ) {
-			$jed = $this->build_jed_json( $po, $entries, $source );
+			$jed  = $this->build_jed_json( $po, $entries, $source );
 			$file = $destination_dir . '/' . $base_file_name . '-' . md5( $source ) . '.json';
 			$json = wp_json_encode( $jed );
 			if ( false === $json ) {
@@ -453,9 +678,9 @@ class Force_Update_Translations {
 	/**
 	 * Build a Jed 1.x compatible data structure for script translations.
 	 *
-	 * @param PO                 $po      Parsed PO (for headers).
+	 * @param PO                  $po      Parsed PO (for headers).
 	 * @param Translation_Entry[] $entries Entries for one JS source file.
-	 * @param string             $source  Relative JS source path.
+	 * @param string              $source  Relative JS source path.
 	 * @return array
 	 */
 	protected function build_jed_json( $po, $entries, $source ) {
@@ -500,7 +725,7 @@ class Force_Update_Translations {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 		$data = get_plugin_data( __FILE__, false, false );
-		return isset( $data['Version'] ) ? $data['Version'] : '0.6.3';
+		return isset( $data['Version'] ) ? $data['Version'] : '0.6.4';
 	}
 
 	/**

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -26,19 +26,6 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 	 * @return array Modified array of plugin action links.
 	 */
 	public function plugin_action_links( $actions, $plugin_file ) {
-		$url         = wp_nonce_url(
-			admin_url( 'plugins.php?force_translate=' . $plugin_file ),
-			'force_translate_plugin_' . $plugin_file,
-			'force_translate_nonce'
-		);
-		$new_actions = array(
-			'force_translate' => sprintf(
-				'<a href="%1$s">%2$s</a>',
-				esc_url( $url ),
-				esc_html__( 'Update translation', 'force-update-translations' )
-			),
-		);
-
 		// Check if plugin is on wordpress.org by checking if ID (from Plugin wp.org info) exists in 'response' or 'no_update'.
 		$on_wporg     = false;
 		$plugin_state = get_site_transient( 'update_plugins' );
@@ -47,9 +34,51 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		}
 
 		// Add action if plugin is on wordpress.org and if user Locale isn't 'en_US'.
-		if ( ( $on_wporg ) && ( get_user_locale() !== 'en_US' ) ) {
-			$actions = array_merge( $actions, $new_actions );
+		if ( ! $on_wporg || get_user_locale() === 'en_US' ) {
+			return $actions;
 		}
+
+		$installed_branch = '';
+		if ( preg_match( '/^([a-zA-Z0-9-_]+)\//', $plugin_file, $plugin_slug ) ) {
+			$installed_branch = $this->detect_installed_branch( 'plugin', $plugin_slug[1] );
+		}
+
+		$branch_links = array();
+		foreach ( array( 'stable', 'dev' ) as $branch ) {
+			$url   = wp_nonce_url(
+				admin_url(
+					add_query_arg(
+						array(
+							'force_translate'        => $plugin_file,
+							'force_translate_branch' => $branch,
+						),
+						'plugins.php'
+					)
+				),
+				'force_translate_plugin_' . $plugin_file . '_' . $branch,
+				'force_translate_nonce'
+			);
+			$label = $this->get_branch_label( $branch );
+			if ( $branch === $installed_branch ) {
+				$label = sprintf(
+					/* translators: %s: Translation project branch (Development or Stable). */
+					__( '%s (current)', 'force-update-translations' ),
+					$label
+				);
+			}
+			$branch_links[] = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $url ),
+				esc_html( $label )
+			);
+		}
+
+		$actions['force_translate'] = sprintf(
+			'%1$s: %2$s',
+			esc_html__( 'Update translation', 'force-update-translations' ),
+			implode( ' | ', $branch_links )
+		);
+
 		return $actions;
 	}
 
@@ -65,10 +94,20 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		}
 
 		$plugin_file = sanitize_text_field( wp_unslash( $_GET['force_translate'] ) );
+		$branch      = isset( $_GET['force_translate_branch'] ) ? sanitize_key( wp_unslash( $_GET['force_translate_branch'] ) ) : '';
+
+		if ( ! in_array( $branch, array( 'stable', 'dev' ), true ) ) {
+			$this->admin_notices['error'][] = array(
+				'status'  => 'error',
+				'content' => esc_html__( 'Please choose Stable or Development as the translation source.', 'force-update-translations' ),
+			);
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+			return;
+		}
 
 		// Verify nonce for CSRF protection.
 		if ( ! isset( $_GET['force_translate_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['force_translate_nonce'] ) ), 'force_translate_plugin_' . $plugin_file ) ) {
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['force_translate_nonce'] ) ), 'force_translate_plugin_' . $plugin_file . '_' . $branch ) ) {
 			$this->admin_notices['error'][] = array(
 				'status'  => 'error',
 				'content' => esc_html__( 'Security verification failed. Please refresh the page and try again.', 'force-update-translations' ),
@@ -122,6 +161,7 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 		$projects = array(
 			$plugin_file => array(
 				'type'        => 'plugin',
+				'branch'      => $branch,
 				'sub_project' => array(
 					'slug' => $plugin_slug[1],
 					'name' => $plugin_data['Name'],

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -119,11 +119,13 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file, false );
 
-		$projects[ $plugin_file ] = array(
-			'type'        => 'plugin',
-			'sub_project' => array(
-				'slug' => $plugin_slug[1],
-				'name' => $plugin_data['Name'],
+		$projects = array(
+			$plugin_file => array(
+				'type'        => 'plugin',
+				'sub_project' => array(
+					'slug' => $plugin_slug[1],
+					'name' => $plugin_data['Name'],
+				),
 			),
 		);
 

--- a/inc/plugins.php
+++ b/inc/plugins.php
@@ -2,9 +2,11 @@
 /**
  * Force update translations for plugins.
  *
- * @package update-force-translations
- * @author mayukojpn
- * @license GPL-2.0+
+ * @package Force_Update_Translations
+ */
+
+/**
+ * Plugin translation update handler.
  */
 class Plugin_Force_Update_Translations extends Force_Update_Translations {
 	/**
@@ -33,8 +35,8 @@ class Plugin_Force_Update_Translations extends Force_Update_Translations {
 			$on_wporg = true;
 		}
 
-		// Add action if plugin is on wordpress.org and if user Locale isn't 'en_US'.
-		if ( ! $on_wporg || get_user_locale() === 'en_US' ) {
+		// Add action if plugin is on wordpress.org and if target locale isn't 'en_US'.
+		if ( ! $on_wporg || $this->get_target_locale() === 'en_US' ) {
 			return $actions;
 		}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,0 +1,421 @@
+<?php
+/**
+ * Settings screen, locale preference, and bulk plugin updates.
+ *
+ * @package Force_Update_Translations
+ */
+
+/**
+ * Admin settings for Force Update Translations.
+ */
+class Force_Update_Translations_Settings extends Force_Update_Translations {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_init', array( $this, 'handle_bulk_update' ) );
+		add_action( 'admin_init', array( $this, 'handle_clear_forced' ) );
+	}
+
+	/**
+	 * Register settings page.
+	 *
+	 * @return void
+	 */
+	public function admin_menu() {
+		add_options_page(
+			__( 'Force Update Translations', 'force-update-translations' ),
+			__( 'Force Update Translations', 'force-update-translations' ),
+			'manage_options',
+			'force-update-translations',
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Register Settings API fields.
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			'fut_settings_group',
+			self::SETTINGS_OPTION,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				'default'           => self::default_settings(),
+			)
+		);
+
+		add_settings_section(
+			'fut_general',
+			__( 'General', 'force-update-translations' ),
+			'__return_false',
+			'force-update-translations'
+		);
+
+		add_settings_field(
+			'locale_source',
+			__( 'Locale source', 'force-update-translations' ),
+			array( $this, 'render_locale_source_field' ),
+			'force-update-translations',
+			'fut_general'
+		);
+
+		add_settings_field(
+			'protect_from_packs',
+			__( 'Language pack protection', 'force-update-translations' ),
+			array( $this, 'render_protect_field' ),
+			'force-update-translations',
+			'fut_general'
+		);
+	}
+
+	/**
+	 * Sanitize settings array.
+	 *
+	 * @param array $input Raw input.
+	 * @return array
+	 */
+	public function sanitize_settings( $input ) {
+		$defaults = self::default_settings();
+		$output   = $defaults;
+
+		if ( ! is_array( $input ) ) {
+			return $output;
+		}
+
+		$output['locale_source']      = ( isset( $input['locale_source'] ) && 'site' === $input['locale_source'] ) ? 'site' : 'user';
+		$output['protect_from_packs'] = empty( $input['protect_from_packs'] ) ? 0 : 1;
+
+		return $output;
+	}
+
+	/**
+	 * Render locale source field.
+	 *
+	 * @return void
+	 */
+	public function render_locale_source_field() {
+		$settings = $this->get_settings();
+		$current  = $settings['locale_source'];
+		?>
+		<fieldset>
+			<label>
+				<input type="radio" name="<?php echo esc_attr( self::SETTINGS_OPTION ); ?>[locale_source]" value="user" <?php checked( $current, 'user' ); ?> />
+				<?php
+				printf(
+					/* translators: %s: locale code */
+					esc_html__( 'User language (%s)', 'force-update-translations' ),
+					esc_html( get_user_locale() )
+				);
+				?>
+			</label>
+			<br />
+			<label>
+				<input type="radio" name="<?php echo esc_attr( self::SETTINGS_OPTION ); ?>[locale_source]" value="site" <?php checked( $current, 'site' ); ?> />
+				<?php
+				printf(
+					/* translators: %s: locale code */
+					esc_html__( 'Site language (%s)', 'force-update-translations' ),
+					esc_html( get_locale() )
+				);
+				?>
+			</label>
+			<p class="description">
+				<?php esc_html_e( 'Controls which locale is used when downloading translations and detecting the installed Stable/Development source.', 'force-update-translations' ); ?>
+			</p>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render overwrite-protection field.
+	 *
+	 * @return void
+	 */
+	public function render_protect_field() {
+		$settings = $this->get_settings();
+		?>
+		<label>
+			<input type="checkbox" name="<?php echo esc_attr( self::SETTINGS_OPTION ); ?>[protect_from_packs]" value="1" <?php checked( ! empty( $settings['protect_from_packs'] ) ); ?> />
+			<?php esc_html_e( 'Prevent official WordPress.org language packs from overwriting forced translations', 'force-update-translations' ); ?>
+		</label>
+		<p class="description">
+			<?php esc_html_e( 'When enabled, translation updates for domains you forced through this plugin are skipped until you clear their protection.', 'force-update-translations' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Handle bulk plugin translation updates.
+	 *
+	 * @return void
+	 */
+	public function handle_bulk_update() {
+		if ( ! isset( $_POST['fut_bulk_update'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to update translation files.', 'force-update-translations' ) );
+		}
+
+		check_admin_referer( 'fut_bulk_update', 'fut_bulk_update_nonce' );
+
+		$branch = isset( $_POST['fut_bulk_branch'] ) ? sanitize_key( wp_unslash( $_POST['fut_bulk_branch'] ) ) : 'stable';
+		if ( ! in_array( $branch, array( 'stable', 'dev' ), true ) ) {
+			$branch = 'stable';
+		}
+
+		$selected = array();
+		if ( isset( $_POST['fut_plugins'] ) ) {
+			$selected = array_map( 'sanitize_text_field', wp_unslash( (array) $_POST['fut_plugins'] ) );
+		}
+
+		$projects = array();
+		foreach ( $selected as $plugin_file ) {
+			if ( ! preg_match( '/^([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+\.php)$/', $plugin_file, $plugin_slug ) ) {
+				continue;
+			}
+
+			$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_file;
+			$real_path   = realpath( $plugin_path );
+			if ( false === $real_path || 0 !== strpos( $real_path, WP_PLUGIN_DIR ) ) {
+				continue;
+			}
+
+			$plugin_data              = get_plugin_data( $plugin_path, false );
+			$projects[ $plugin_file ] = array(
+				'type'        => 'plugin',
+				'branch'      => $branch,
+				'sub_project' => array(
+					'slug' => $plugin_slug[1],
+					'name' => $plugin_data['Name'],
+				),
+			);
+		}
+
+		if ( empty( $projects ) ) {
+			$this->admin_notices['bulk'][] = array(
+				'status'  => 'error',
+				'content' => esc_html__( 'No valid plugins were selected.', 'force-update-translations' ),
+			);
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+			return;
+		}
+
+		$this->get_files( $projects );
+	}
+
+	/**
+	 * Clear forced-translation protection entries.
+	 *
+	 * @return void
+	 */
+	public function handle_clear_forced() {
+		if ( ! isset( $_POST['fut_clear_forced'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to update translation files.', 'force-update-translations' ) );
+		}
+
+		check_admin_referer( 'fut_clear_forced', 'fut_clear_forced_nonce' );
+
+		$removed                        = $this->clear_forced_translations();
+		$this->admin_notices['clear'][] = array(
+			'status'  => 'success',
+			'content' => sprintf(
+				/* translators: %d: number of entries */
+				esc_html( _n( 'Cleared protection for %d translation.', 'Cleared protection for %d translations.', $removed, 'force-update-translations' ) ),
+				(int) $removed
+			),
+		);
+		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+	}
+
+	/**
+	 * WordPress.org plugins available for bulk update.
+	 *
+	 * @return array plugin_file => plugin name
+	 */
+	protected function get_wporg_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$all          = get_plugins();
+		$plugin_state = get_site_transient( 'update_plugins' );
+		$available    = array();
+
+		foreach ( $all as $plugin_file => $data ) {
+			$on_wporg = isset( $plugin_state->response[ $plugin_file ]->id ) || isset( $plugin_state->no_update[ $plugin_file ]->id );
+			if ( ! $on_wporg ) {
+				continue;
+			}
+			if ( ! preg_match( '/^([a-zA-Z0-9-_]+)\//', $plugin_file ) ) {
+				continue;
+			}
+			$available[ $plugin_file ] = $data['Name'];
+		}
+
+		asort( $available, SORT_NATURAL | SORT_FLAG_CASE );
+		return $available;
+	}
+
+	/**
+	 * Render settings page.
+	 *
+	 * @return void
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$plugins = $this->get_wporg_plugins();
+		$forced  = $this->get_forced_translations();
+		$locale  = $this->get_target_locale();
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( 'fut_settings_group' );
+				do_settings_sections( 'force-update-translations' );
+				submit_button( __( 'Save settings', 'force-update-translations' ) );
+				?>
+			</form>
+
+			<hr />
+
+			<h2><?php esc_html_e( 'Bulk update plugin translations', 'force-update-translations' ); ?></h2>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: locale code */
+					esc_html__( 'Downloads will use locale: %s', 'force-update-translations' ),
+					'<code>' . esc_html( $locale ) . '</code>'
+				);
+				?>
+			</p>
+
+			<?php if ( 'en_US' === $locale ) : ?>
+				<p><?php esc_html_e( 'The target locale is en_US, so translation downloads are not available.', 'force-update-translations' ); ?></p>
+			<?php elseif ( empty( $plugins ) ) : ?>
+				<p><?php esc_html_e( 'No WordPress.org plugins were found. Visit Plugins to refresh update data, then return here.', 'force-update-translations' ); ?></p>
+			<?php else : ?>
+				<form method="post" action="">
+					<?php wp_nonce_field( 'fut_bulk_update', 'fut_bulk_update_nonce' ); ?>
+					<p>
+						<label for="fut_bulk_branch"><?php esc_html_e( 'Source', 'force-update-translations' ); ?></label>
+						<select name="fut_bulk_branch" id="fut_bulk_branch">
+							<option value="stable"><?php echo esc_html( $this->get_branch_label( 'stable' ) ); ?></option>
+							<option value="dev"><?php echo esc_html( $this->get_branch_label( 'dev' ) ); ?></option>
+						</select>
+					</p>
+					<table class="widefat striped">
+						<thead>
+							<tr>
+								<td class="manage-column column-cb check-column"><input type="checkbox" id="fut-select-all" /></td>
+								<th><?php esc_html_e( 'Plugin', 'force-update-translations' ); ?></th>
+								<th><?php esc_html_e( 'Installed source', 'force-update-translations' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $plugins as $plugin_file => $name ) : ?>
+								<?php
+								$slug   = dirname( $plugin_file );
+								$branch = $this->detect_installed_branch( 'plugin', $slug, $locale );
+								?>
+								<tr>
+									<th scope="row" class="check-column">
+										<input type="checkbox" name="fut_plugins[]" value="<?php echo esc_attr( $plugin_file ); ?>" />
+									</th>
+									<td>
+										<strong><?php echo esc_html( $name ); ?></strong>
+										<br /><code><?php echo esc_html( $plugin_file ); ?></code>
+									</td>
+									<td>
+										<?php
+										echo '' !== $branch
+											? esc_html( $this->get_branch_label( $branch ) )
+											: esc_html__( 'Unknown / not forced yet', 'force-update-translations' );
+										?>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+					<?php submit_button( __( 'Update selected translations', 'force-update-translations' ), 'primary', 'fut_bulk_update' ); ?>
+				</form>
+				<script>
+				(function () {
+					var master = document.getElementById('fut-select-all');
+					if (!master) { return; }
+					master.addEventListener('change', function () {
+						document.querySelectorAll('input[name="fut_plugins[]"]').forEach(function (el) {
+							el.checked = master.checked;
+						});
+					});
+				})();
+				</script>
+			<?php endif; ?>
+
+			<hr />
+
+			<h2><?php esc_html_e( 'Protected forced translations', 'force-update-translations' ); ?></h2>
+			<?php if ( empty( $forced ) ) : ?>
+				<p><?php esc_html_e( 'No forced translations are currently protected.', 'force-update-translations' ); ?></p>
+			<?php else : ?>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'Type', 'force-update-translations' ); ?></th>
+							<th><?php esc_html_e( 'Slug', 'force-update-translations' ); ?></th>
+							<th><?php esc_html_e( 'Locale', 'force-update-translations' ); ?></th>
+							<th><?php esc_html_e( 'Source', 'force-update-translations' ); ?></th>
+							<th><?php esc_html_e( 'Updated', 'force-update-translations' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $forced as $entry ) : ?>
+							<tr>
+								<td><?php echo esc_html( isset( $entry['type'] ) ? $entry['type'] : '' ); ?></td>
+								<td><?php echo esc_html( isset( $entry['slug'] ) ? $entry['slug'] : '' ); ?></td>
+								<td><?php echo esc_html( isset( $entry['locale'] ) ? $entry['locale'] : '' ); ?></td>
+								<td>
+									<?php
+									$branch = isset( $entry['branch'] ) ? $entry['branch'] : '';
+									echo '' !== $branch ? esc_html( $this->get_branch_label( $branch ) ) : '&mdash;';
+									?>
+								</td>
+								<td>
+									<?php
+									echo isset( $entry['updated'] )
+										? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $entry['updated'] ) )
+										: '&mdash;';
+									?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+				<form method="post" action="" style="margin-top: 1em;">
+					<?php wp_nonce_field( 'fut_clear_forced', 'fut_clear_forced_nonce' ); ?>
+					<?php submit_button( __( 'Clear all protection', 'force-update-translations' ), 'secondary', 'fut_clear_forced' ); ?>
+				</form>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+}
+
+new Force_Update_Translations_Settings();

--- a/inc/themes.php
+++ b/inc/themes.php
@@ -1,18 +1,20 @@
 <?php
 /**
- * Theme translation update handler class.
+ * Theme translation update handler.
  *
- * @package update-force-translations
- * @author mayukojpn
- * @license GPL-2.0+
+ * @package Force_Update_Translations
+ */
+
+/**
+ * Theme translation update handler class.
  */
 class Theme_Force_Update_Translations extends Force_Update_Translations {
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		// Add theme translation option if user Locale is not 'en_US'.
-		if ( get_user_locale() !== 'en_US' ) {
+		// Add theme translation option if target locale is not 'en_US'.
+		if ( $this->get_target_locale() !== 'en_US' ) {
 			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 5.6
-Stable tag: 0.6.2
+Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 5.6
-Stable tag: 0.6.1
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: translation
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 5.6
-Stable tag: 0.6.3
+Stable tag: 0.6.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,31 +14,22 @@ Apply WordPress.org theme and plugin translations to a site even if translations
 
 Apply WordPress.org theme and plugin translations to a site even if translations are not yet approved or language packs have not been released.
 
-**Note about Translation Playground:**
-The [Translation Playground](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/) is now available for quick translation testing. However, if you need to test translations on your actual site, this plugin may remain the practical solution.
-
-⚠️ Warning ⚠️ Currently this plugin downloads only strings from Development project instead of Stable for plugins. Please wait for an update or see <a href="https://github.com/mayukojpn/force-update-translations/issues/37">the issue on GitHub</a>.
-
-⚠️ Warning ⚠️ Currently this plugin is not able to generate the JSON files that is needed for JavaScript to consume some translations. Please wait for update or see <a href="https://github.com/mayukojpn/force-update-translations/issues/24">the issue on GitHub</a>.
-
-== Theme translation ==
-
-To download the translation files for a theme:
-
-1. Activate the theme you want to get the translation files.
-1. Visit 'Appearance' > 'Update translation' in WordPress menu, or click 'Update translation' on theme details of current theme on 'Themes' page.
-1. Click the 'Update Translations' button.
+This plugin exports translations from translate.wordpress.org including Current, Waiting (suggestions), and Fuzzy strings, writes them into your site language directory, and generates Jed JSON files so JavaScript translations can apply as well.
 
 == Plugin translation ==
 
-To download the translation files for a plugin:
-
 1. Visit 'Plugins' in WordPress menu.
-1. Click 'Update translation' under the name of the plugin for which you want to get the translation files.
+1. Under the plugin name, choose 'Update translation: Stable' or 'Development'.
 
-== Screenshots ==
+== Theme translation ==
 
-1. "Update translation" link will be shown in your plugins list.
+1. Activate the theme you want to get the translation files.
+1. Visit 'Appearance' > 'Update translation' in the WordPress admin.
+1. Click the 'Update translation' button.
+
+== Settings ==
+
+Visit 'Settings' > 'Force Update Translations' to choose the locale source (user or site language), protect forced translations from official language-pack overwrites, and bulk-update plugin translations.
 
 == Changelog ==
 


### PR DESCRIPTION
## Summary
- **Depends on #45**（Stable/Development 選択・JSON 生成のあとでマージしてください）
- 設定画面（Settings → Force Update Translations）を追加
- 取得ロケールをユーザー言語 / サイト言語から選択可能に
- 強制取得した翻訳を公式 language pack の上書きから保護
- インストール済み WordPress.org プラグインの一括翻訳更新

## Test plan
- [ ] Settings → Force Update Translations が開ける
- [ ] ロケールソースを切り替えると、プラグイン一覧の取得対象ロケールが変わる
- [ ] 強制更新後、保護一覧にエントリが追加される
- [ ] 保護 ON のとき、該当ドメインの language pack 更新がスキップされる
- [ ] 一括更新で複数プラグインを Stable / Development 指定で取得できる
- [ ] 保護クリア後は通常の language pack 更新に戻る


Made with [Cursor](https://cursor.com)